### PR TITLE
Convert integers to nullable-integers if p(NA)>0

### DIFF
--- a/metasynth/var.py
+++ b/metasynth/var.py
@@ -69,6 +69,9 @@ class MetaVar():
             raise ValueError(f"Error while initializing variable {self.name}."
                              " prop_missing is None.")
 
+        if self.prop_missing > 0 and str(self.dtype).startswith("int"):
+            self.dtype = pd.Int64Dtype()
+
     @classmethod
     def detect(cls, series_or_dataframe: Union[pd.Series, pd.DataFrame],
                description: str=None, prop_missing: float=None):


### PR DESCRIPTION
Fixes #74 

The problem is that pandas makes a distinction between integers and nullable integers. Therefore, a column/series that wasn't originally a nullable integer, needs to be converted to one if prop_missing is manually set.