### PR TITLE
Remove inheritance in favor of properties

### DIFF
--- a/metasynth/__init__.py
+++ b/metasynth/__init__.py
@@ -10,6 +10,7 @@ from importlib.metadata import version
 from metasynth.dataset import MetaDataset
 from metasynth.var import MetaVar
 from metasynth.demo.dataset import demo_file
+from metasynth.distribution.base import distribution
 
 __all__ = ["MetaVar", "MetaDataset", "demo_file"]
 __version__ = version("metasynth")

--- a/metasynth/__init__.py
+++ b/metasynth/__init__.py
@@ -10,7 +10,7 @@ from importlib.metadata import version
 from metasynth.dataset import MetaDataset
 from metasynth.var import MetaVar
 from metasynth.demo.dataset import demo_file
-from metasynth.distribution.base import distclass
+from metasynth.distribution.base import metadist
 
-__all__ = ["MetaVar", "MetaDataset", "demo_file", "distclass"]
+__all__ = ["MetaVar", "MetaDataset", "demo_file", "metadist"]
 __version__ = version("metasynth")

--- a/metasynth/__init__.py
+++ b/metasynth/__init__.py
@@ -10,7 +10,7 @@ from importlib.metadata import version
 from metasynth.dataset import MetaDataset
 from metasynth.var import MetaVar
 from metasynth.demo.dataset import demo_file
-from metasynth.distribution.base import distribution
+from metasynth.distribution.base import distclass
 
-__all__ = ["MetaVar", "MetaDataset", "demo_file", "distribution"]
+__all__ = ["MetaVar", "MetaDataset", "demo_file", "distclass"]
 __version__ = version("metasynth")

--- a/metasynth/__init__.py
+++ b/metasynth/__init__.py
@@ -12,5 +12,5 @@ from metasynth.var import MetaVar
 from metasynth.demo.dataset import demo_file
 from metasynth.distribution.base import distribution
 
-__all__ = ["MetaVar", "MetaDataset", "demo_file"]
+__all__ = ["MetaVar", "MetaDataset", "demo_file", "distribution"]
 __version__ = version("metasynth")

--- a/metasynth/distribution/__init__.py
+++ b/metasynth/distribution/__init__.py
@@ -5,12 +5,6 @@ somewhat realistic. The concept of distributions here is not only for
 numerical data, but also for generating strings for example.
 """  # pylint: disable=invalid-name
 
-from metasynth.distribution.base import (CategoricalDistribution,
-                                         ContinuousDistribution,
-                                         DateDistribution,
-                                         DateTimeDistribution,
-                                         DiscreteDistribution,
-                                         StringDistribution, TimeDistribution)
 from metasynth.distribution.categorical import MultinoulliDistribution
 from metasynth.distribution.continuous import (ExponentialDistribution,
                                                LogNormalDistribution,

--- a/metasynth/distribution/__init__.py
+++ b/metasynth/distribution/__init__.py
@@ -22,8 +22,6 @@ from metasynth.distribution.regex import (RegexDistribution,
                                           UniqueRegexDistribution)
 
 __all__ = [
-    "DiscreteDistribution", "ContinuousDistribution", "CategoricalDistribution",
-    "DateDistribution", "DateTimeDistribution", "StringDistribution", "TimeDistribution",
     "MultinoulliDistribution", "UniformDistribution", "NormalDistribution",
     "LogNormalDistribution", "TruncatedNormalDistribution", "ExponentialDistribution",
     "DiscreteUniformDistribution", "PoissonDistribution", "UniqueKeyDistribution",

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -152,7 +152,7 @@ class BaseDistribution(ABC):
 def distribution(implements: Optional[str] = None, provenance: Optional[str] = None,
                  var_type: Optional[str] = None, is_unique: Optional[bool] = None,
                  privacy: Optional[str] = None):
-    """Decorator to create a distribution from a class.
+    """Decorate class to create a distribution with the right properties.
 
     Parameters
     ----------

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -18,11 +18,11 @@ class BaseDistribution(ABC):
     methods need to be implemented: _fit, draw, to_dict.
     """
 
-    implements = "unknown"
-    provenance = "unknown"
-    privacy = "unknown"
-    is_unique = False
+    implements: str = "unknown"
     var_type: str = "unknown"
+    provenance: str = "builtin"
+    privacy: str = "none"
+    is_unique: bool = False
 
     @classmethod
     def fit(cls, series: Union[Sequence, pl.Series], *args, **kwargs) -> BaseDistribution:
@@ -150,53 +150,20 @@ class BaseDistribution(ABC):
         return cls()
 
 
-class CoreDistribution():  # pylint: disable=too-few-public-methods
-    """Distributions belonging to the core set."""
-
-    privacy = "none"
-    provenance = "builtin"
-
-
-class CategoricalDistribution(BaseDistribution):
-    """Base Class for categorical distributions."""
-
-    var_type = "categorical"
-
-
-class DiscreteDistribution(BaseDistribution):
-    """Base Class for discrete distributions."""
-
-    var_type = "discrete"
-
-
-class ContinuousDistribution(BaseDistribution):
-    """Base Class for continuous distributions."""
-
-    var_type = "continuous"
-
-
-class StringDistribution(BaseDistribution):
-    """Base Class for string distributions."""
-
-    var_type = "string"
-
-
-class DateTimeDistribution(BaseDistribution):
-    """Base Class for date-time distributions."""
-
-    var_type = "datetime"
-
-
-class DateDistribution(BaseDistribution):
-    """Base Class for date distributions."""
-
-    var_type = "date"
-
-
-class TimeDistribution(BaseDistribution):
-    """Base Class for time distributions."""
-
-    var_type = "time"
+def distribution(implements=None, provenance=None, var_type=None, is_unique=None, privacy=None):
+    def _wrap(cls):
+        if implements is not None:
+            cls.implements = implements
+        if provenance is not None:
+            cls.provenance = provenance
+        if var_type is not None:
+            cls.var_type = var_type
+        if is_unique is not None:
+            cls.is_unique = is_unique
+        if privacy is not None:
+            cls.privacy = privacy
+        return cls
+    return _wrap
 
 
 class ScipyDistribution(BaseDistribution):

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -149,9 +149,9 @@ class BaseDistribution(ABC):
         return cls()
 
 
-def distclass(implements: Optional[str] = None, provenance: Optional[str] = None,
-              var_type: Optional[str] = None, is_unique: Optional[bool] = None,
-              privacy: Optional[str] = None):
+def metadist(implements: Optional[str] = None, provenance: Optional[str] = None,
+             var_type: Optional[str] = None, is_unique: Optional[bool] = None,
+             privacy: Optional[str] = None):
     """Decorate class to create a distribution with the right properties.
 
     Parameters

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -149,9 +149,9 @@ class BaseDistribution(ABC):
         return cls()
 
 
-def distribution(implements: Optional[str]=None, provenance: Optional[str]=None,
-                 var_type: Optional[str]=None, is_unique: Optional[bool]=None,
-                 privacy: Optional[str]=None):
+def distribution(implements: Optional[str] = None, provenance: Optional[str] = None,
+                 var_type: Optional[str] = None, is_unique: Optional[bool] = None,
+                 privacy: Optional[str] = None):
     """Decorator to create a distribution from a class.
 
     Parameters

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -149,9 +149,9 @@ class BaseDistribution(ABC):
         return cls()
 
 
-def distribution(implements: Optional[str] = None, provenance: Optional[str] = None,
-                 var_type: Optional[str] = None, is_unique: Optional[bool] = None,
-                 privacy: Optional[str] = None):
+def distclass(implements: Optional[str] = None, provenance: Optional[str] = None,
+              var_type: Optional[str] = None, is_unique: Optional[bool] = None,
+              privacy: Optional[str] = None):
     """Decorate class to create a distribution with the right properties.
 
     Parameters

--- a/metasynth/distribution/base.py
+++ b/metasynth/distribution/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Iterable, Sequence, Union
+from typing import Iterable, Sequence, Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -41,8 +41,7 @@ class BaseDistribution(ABC):
         pd_series = cls._to_series(series)
         if len(pd_series) == 0:
             return cls.default_distribution()
-        distribution = cls._fit(pd_series, *args, **kwargs)
-        return distribution
+        return cls._fit(pd_series, *args, **kwargs)
 
     @staticmethod
     def _to_series(values: Union[Sequence, pl.Series]):
@@ -150,7 +149,29 @@ class BaseDistribution(ABC):
         return cls()
 
 
-def distribution(implements=None, provenance=None, var_type=None, is_unique=None, privacy=None):
+def distribution(implements: Optional[str]=None, provenance: Optional[str]=None,
+                 var_type: Optional[str]=None, is_unique: Optional[bool]=None,
+                 privacy: Optional[str]=None):
+    """Decorator to create a distribution from a class.
+
+    Parameters
+    ----------
+    implements:
+        The distribution ID that it implements, e.g. core.uniform, core.regex.
+    provenance:
+        Where the distribution came from, which package/plugin implemented it.
+    var_type:
+        Variable type of the distribution, e.g. continuous, categorical, string.
+    is_unique:
+        Whether the distribution is unique or not.
+    privacy:
+        Privacy class/implementation of the distribution.
+
+    Returns
+    -------
+    cls:
+        Class with the appropriate class variables.
+    """
     def _wrap(cls):
         if implements is not None:
             cls.implements = implements

--- a/metasynth/distribution/categorical.py
+++ b/metasynth/distribution/categorical.py
@@ -10,10 +10,10 @@ import numpy.typing as npt
 import pandas as pd
 import polars as pl
 
-from metasynth.distribution.base import distribution, BaseDistribution
+from metasynth.distribution.base import distclass, BaseDistribution
 
 
-@distribution(implements="core.multinoulli", var_type="categorical")
+@distclass(implements="core.multinoulli", var_type="categorical")
 class MultinoulliDistribution(BaseDistribution):
     """Categorical distribution that stores category labels and probabilities.
 

--- a/metasynth/distribution/categorical.py
+++ b/metasynth/distribution/categorical.py
@@ -10,10 +10,10 @@ import numpy.typing as npt
 import pandas as pd
 import polars as pl
 
-from metasynth.distribution.base import distclass, BaseDistribution
+from metasynth.distribution.base import metadist, BaseDistribution
 
 
-@distclass(implements="core.multinoulli", var_type="categorical")
+@metadist(implements="core.multinoulli", var_type="categorical")
 class MultinoulliDistribution(BaseDistribution):
     """Categorical distribution that stores category labels and probabilities.
 

--- a/metasynth/distribution/categorical.py
+++ b/metasynth/distribution/categorical.py
@@ -10,11 +10,11 @@ import numpy.typing as npt
 import pandas as pd
 import polars as pl
 
-from metasynth.distribution.base import (CategoricalDistribution,
-                                         CoreDistribution)
+from metasynth.distribution.base import distribution, BaseDistribution
 
 
-class MultinoulliDistribution(CoreDistribution, CategoricalDistribution):
+@distribution(implements="core.multinoulli", var_type="categorical")
+class MultinoulliDistribution(BaseDistribution):
     """Categorical distribution that stores category labels and probabilities.
 
     Parameters
@@ -25,8 +25,6 @@ class MultinoulliDistribution(CoreDistribution, CategoricalDistribution):
         List containing the probability of each category.
         Probabilities will be normalized, so frequencies are valid too.
     """
-
-    implements = "core.multinoulli"
 
     def __init__(self, labels: Union[npt.NDArray[np.str_], list[str]],
                  probs: Union[npt.NDArray[np.float_], list[float]]):

--- a/metasynth/distribution/continuous.py
+++ b/metasynth/distribution/continuous.py
@@ -5,10 +5,10 @@ from scipy.optimize import minimize
 from scipy.stats import expon, lognorm, norm, truncnorm, uniform
 from scipy.stats._continuous_distns import FitDataError
 
-from metasynth.distribution.base import distribution, ScipyDistribution
+from metasynth.distribution.base import distclass, ScipyDistribution
 
 
-@distribution(implements="core.uniform", var_type="continuous")
+@distclass(implements="core.uniform", var_type="continuous")
 class UniformDistribution(ScipyDistribution):
     """Uniform distribution for floating point type.
 
@@ -52,7 +52,7 @@ class UniformDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.normal", var_type="continuous")
+@distclass(implements="core.normal", var_type="continuous")
 class NormalDistribution(ScipyDistribution):
     """Normal distribution for floating point type.
 
@@ -87,7 +87,7 @@ class NormalDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.lognormal", var_type="continuous")
+@distclass(implements="core.lognormal", var_type="continuous")
 class LogNormalDistribution(ScipyDistribution):
     """Log-normal distribution for floating point type.
 
@@ -127,7 +127,7 @@ class LogNormalDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.truncated_normal", var_type="continuous")
+@distclass(implements="core.truncated_normal", var_type="continuous")
 class TruncatedNormalDistribution(ScipyDistribution):
     """Truncated normal distribution for floating point type.
 
@@ -186,7 +186,7 @@ class TruncatedNormalDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.exponential", var_type="continuous")
+@distclass(implements="core.exponential", var_type="continuous")
 class ExponentialDistribution(ScipyDistribution):
     """Exponential distribution for floating point type.
 

--- a/metasynth/distribution/continuous.py
+++ b/metasynth/distribution/continuous.py
@@ -5,11 +5,11 @@ from scipy.optimize import minimize
 from scipy.stats import expon, lognorm, norm, truncnorm, uniform
 from scipy.stats._continuous_distns import FitDataError
 
-from metasynth.distribution.base import (ContinuousDistribution,
-                                         CoreDistribution, ScipyDistribution)
+from metasynth.distribution.base import distribution, ScipyDistribution
 
 
-class UniformDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribution):
+@distribution(implements="core.uniform", var_type="continuous")
+class UniformDistribution(ScipyDistribution):
     """Uniform distribution for floating point type.
 
     This class implements the uniform distribution between a minimum
@@ -23,7 +23,6 @@ class UniformDistribution(CoreDistribution, ScipyDistribution, ContinuousDistrib
         Upper bound for uniform distribution.
     """
 
-    implements = "core.uniform"
     dist_class = uniform
 
     def __init__(self, min_val: float, max_val: float):
@@ -53,7 +52,8 @@ class UniformDistribution(CoreDistribution, ScipyDistribution, ContinuousDistrib
         }
 
 
-class NormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribution):
+@distribution(implements="core.normal", var_type="continuous")
+class NormalDistribution(ScipyDistribution):
     """Normal distribution for floating point type.
 
     This class implements the normal/gaussian distribution and takes
@@ -87,7 +87,8 @@ class NormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribu
         }
 
 
-class LogNormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribution):
+@distribution(implements="core.lognormal", var_type="continuous")
+class LogNormalDistribution(ScipyDistribution):
     """Log-normal distribution for floating point type.
 
     This class implements the log-normal mu and sigma as initialization input.
@@ -100,7 +101,6 @@ class LogNormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistr
         Controls the mean of the distribution.
     """
 
-    implements = "core.lognormal"
     dist_class = lognorm
 
     def __init__(self, mu: float, sigma: float):  # pylint: disable=invalid-name
@@ -127,7 +127,8 @@ class LogNormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistr
         }
 
 
-class TruncatedNormalDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribution):
+@distribution(implements="core.truncated_normal", var_type="continuous")
+class TruncatedNormalDistribution(ScipyDistribution):
     """Truncated normal distribution for floating point type.
 
     Parameters
@@ -142,7 +143,6 @@ class TruncatedNormalDistribution(CoreDistribution, ScipyDistribution, Continuou
         Standard deviation of the non-truncated normal distribution.
     """
 
-    implements = "core.truncated_normal"
     dist_class = truncnorm
 
     def __init__(self, lower_bound: float, upper_bound: float,
@@ -186,7 +186,8 @@ class TruncatedNormalDistribution(CoreDistribution, ScipyDistribution, Continuou
         }
 
 
-class ExponentialDistribution(CoreDistribution, ScipyDistribution, ContinuousDistribution):
+@distribution(implements="core.exponential", var_type="continuous")
+class ExponentialDistribution(ScipyDistribution):
     """Exponential distribution for floating point type.
 
     This class implements the exponential distribution with the rate as its
@@ -198,7 +199,6 @@ class ExponentialDistribution(CoreDistribution, ScipyDistribution, ContinuousDis
         Rate of the exponential distribution. This is equal to 1/mean of the distribution.
     """
 
-    implements = "core.exponential"
     dist_class = expon
 
     def __init__(self, rate: float):

--- a/metasynth/distribution/continuous.py
+++ b/metasynth/distribution/continuous.py
@@ -5,10 +5,10 @@ from scipy.optimize import minimize
 from scipy.stats import expon, lognorm, norm, truncnorm, uniform
 from scipy.stats._continuous_distns import FitDataError
 
-from metasynth.distribution.base import distclass, ScipyDistribution
+from metasynth.distribution.base import metadist, ScipyDistribution
 
 
-@distclass(implements="core.uniform", var_type="continuous")
+@metadist(implements="core.uniform", var_type="continuous")
 class UniformDistribution(ScipyDistribution):
     """Uniform distribution for floating point type.
 
@@ -52,7 +52,7 @@ class UniformDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.normal", var_type="continuous")
+@metadist(implements="core.normal", var_type="continuous")
 class NormalDistribution(ScipyDistribution):
     """Normal distribution for floating point type.
 
@@ -87,7 +87,7 @@ class NormalDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.lognormal", var_type="continuous")
+@metadist(implements="core.lognormal", var_type="continuous")
 class LogNormalDistribution(ScipyDistribution):
     """Log-normal distribution for floating point type.
 
@@ -127,7 +127,7 @@ class LogNormalDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.truncated_normal", var_type="continuous")
+@metadist(implements="core.truncated_normal", var_type="continuous")
 class TruncatedNormalDistribution(ScipyDistribution):
     """Truncated normal distribution for floating point type.
 
@@ -186,7 +186,7 @@ class TruncatedNormalDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.exponential", var_type="continuous")
+@metadist(implements="core.exponential", var_type="continuous")
 class ExponentialDistribution(ScipyDistribution):
     """Exponential distribution for floating point type.
 

--- a/metasynth/distribution/datetime.py
+++ b/metasynth/distribution/datetime.py
@@ -7,9 +7,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from metasynth.distribution.base import (CoreDistribution, DateDistribution,
-                                         DateTimeDistribution,
-                                         ScipyDistribution, TimeDistribution)
+from metasynth.distribution.base import distribution, ScipyDistribution
 
 
 def convert_numpy_datetime(time_obj: np.datetime64) -> dt.datetime:
@@ -114,10 +112,9 @@ class BaseUniformDistribution(ScipyDistribution):
         }
 
 
-class UniformDateTimeDistribution(CoreDistribution, DateTimeDistribution, BaseUniformDistribution):
+@distribution(implements="core.uniform_datetime", var_type="datetime")
+class UniformDateTimeDistribution(BaseUniformDistribution):
     """Uniform DateTime distribution."""
-
-    implements = "core.uniform_datetime"
 
     def fromisoformat(self, dt_obj: str) -> dt.datetime:
         return dt.datetime.fromisoformat(dt_obj)
@@ -135,10 +132,9 @@ class UniformDateTimeDistribution(CoreDistribution, DateTimeDistribution, BaseUn
         }
 
 
-class UniformTimeDistribution(CoreDistribution, TimeDistribution, BaseUniformDistribution):
+@distribution(implements="core.uniform_time", var_type="time")
+class UniformTimeDistribution(BaseUniformDistribution):
     """Uniform time distribution."""
-
-    implements = "core.uniform_time"
 
     def fromisoformat(self, dt_obj: str) -> dt.time:
         return dt.time.fromisoformat(dt_obj)
@@ -162,10 +158,10 @@ class UniformTimeDistribution(CoreDistribution, TimeDistribution, BaseUniformDis
         }
 
 
-class UniformDateDistribution(CoreDistribution, DateDistribution, BaseUniformDistribution):
+@distribution(implements="core.uniform_date", var_type="date")
+class UniformDateDistribution(BaseUniformDistribution):
     """Uniform date distribution."""
 
-    implements = "core.uniform_date"
     precision_possibilities = ["days"]
 
     def __init__(self, start: Any, end: Any):

--- a/metasynth/distribution/datetime.py
+++ b/metasynth/distribution/datetime.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from metasynth.distribution.base import distribution, ScipyDistribution
+from metasynth.distribution.base import distclass, ScipyDistribution
 
 
 def convert_numpy_datetime(time_obj: np.datetime64) -> dt.datetime:
@@ -112,7 +112,7 @@ class BaseUniformDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.uniform_datetime", var_type="datetime")
+@distclass(implements="core.uniform_datetime", var_type="datetime")
 class UniformDateTimeDistribution(BaseUniformDistribution):
     """Uniform DateTime distribution."""
 
@@ -132,7 +132,7 @@ class UniformDateTimeDistribution(BaseUniformDistribution):
         }
 
 
-@distribution(implements="core.uniform_time", var_type="time")
+@distclass(implements="core.uniform_time", var_type="time")
 class UniformTimeDistribution(BaseUniformDistribution):
     """Uniform time distribution."""
 
@@ -158,7 +158,7 @@ class UniformTimeDistribution(BaseUniformDistribution):
         }
 
 
-@distribution(implements="core.uniform_date", var_type="date")
+@distclass(implements="core.uniform_date", var_type="date")
 class UniformDateDistribution(BaseUniformDistribution):
     """Uniform date distribution."""
 

--- a/metasynth/distribution/datetime.py
+++ b/metasynth/distribution/datetime.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from metasynth.distribution.base import distclass, ScipyDistribution
+from metasynth.distribution.base import metadist, ScipyDistribution
 
 
 def convert_numpy_datetime(time_obj: np.datetime64) -> dt.datetime:
@@ -112,7 +112,7 @@ class BaseUniformDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.uniform_datetime", var_type="datetime")
+@metadist(implements="core.uniform_datetime", var_type="datetime")
 class UniformDateTimeDistribution(BaseUniformDistribution):
     """Uniform DateTime distribution."""
 
@@ -132,7 +132,7 @@ class UniformDateTimeDistribution(BaseUniformDistribution):
         }
 
 
-@distclass(implements="core.uniform_time", var_type="time")
+@metadist(implements="core.uniform_time", var_type="time")
 class UniformTimeDistribution(BaseUniformDistribution):
     """Uniform time distribution."""
 
@@ -158,7 +158,7 @@ class UniformTimeDistribution(BaseUniformDistribution):
         }
 
 
-@distclass(implements="core.uniform_date", var_type="date")
+@metadist(implements="core.uniform_date", var_type="date")
 class UniformDateDistribution(BaseUniformDistribution):
     """Uniform date distribution."""
 

--- a/metasynth/distribution/discrete.py
+++ b/metasynth/distribution/discrete.py
@@ -5,12 +5,12 @@ from typing import Set
 import numpy as np
 from scipy.stats import poisson, randint
 
-from metasynth.distribution.base import (CoreDistribution,
-                                         DiscreteDistribution,
+from metasynth.distribution.base import (distribution,
                                          ScipyDistribution)
 
 
-class DiscreteUniformDistribution(CoreDistribution, ScipyDistribution, DiscreteDistribution):
+@distribution(implements="core.discrete_uniform", var_type="discrete")
+class DiscreteUniformDistribution(ScipyDistribution):
     """Integer uniform distribution.
 
     It differs from the floating point uniform distribution by
@@ -24,7 +24,6 @@ class DiscreteUniformDistribution(CoreDistribution, ScipyDistribution, DiscreteD
         Upper bound (exclusive) of the uniform distribution.
     """
 
-    implements = "core.discrete_uniform"
     dist_class = randint
 
     def __init__(self, low: int, high: int):
@@ -51,10 +50,10 @@ class DiscreteUniformDistribution(CoreDistribution, ScipyDistribution, DiscreteD
         }
 
 
-class PoissonDistribution(CoreDistribution, ScipyDistribution, DiscreteDistribution):
+@distribution(implements="core.poisson", var_type="discrete")
+class PoissonDistribution(ScipyDistribution):
     """Poisson distribution."""
 
-    implements = "core.poisson"
     dist_class = poisson
 
     def __init__(self, mu: float):
@@ -79,7 +78,8 @@ class PoissonDistribution(CoreDistribution, ScipyDistribution, DiscreteDistribut
         }
 
 
-class UniqueKeyDistribution(CoreDistribution, ScipyDistribution, DiscreteDistribution):
+@distribution(implements="core.unique_key", var_type="discrete", is_unique=True)
+class UniqueKeyDistribution(ScipyDistribution):
     """Integer distribution with unique keys.
 
     Discrete distribution that ensures the uniqueness of the drawn values.
@@ -91,9 +91,6 @@ class UniqueKeyDistribution(CoreDistribution, ScipyDistribution, DiscreteDistrib
     consecutive: int
         1 if keys are consecutive and increasing, 0 otherwise.
     """
-
-    implements = "core.unique_key"
-    is_unique = True
 
     def __init__(self, low: int, consecutive: int):
         self.par = {"low": low, "consecutive": consecutive}

--- a/metasynth/distribution/discrete.py
+++ b/metasynth/distribution/discrete.py
@@ -5,11 +5,11 @@ from typing import Set
 import numpy as np
 from scipy.stats import poisson, randint
 
-from metasynth.distribution.base import (distribution,
+from metasynth.distribution.base import (distclass,
                                          ScipyDistribution)
 
 
-@distribution(implements="core.discrete_uniform", var_type="discrete")
+@distclass(implements="core.discrete_uniform", var_type="discrete")
 class DiscreteUniformDistribution(ScipyDistribution):
     """Integer uniform distribution.
 
@@ -50,7 +50,7 @@ class DiscreteUniformDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.poisson", var_type="discrete")
+@distclass(implements="core.poisson", var_type="discrete")
 class PoissonDistribution(ScipyDistribution):
     """Poisson distribution."""
 
@@ -78,7 +78,7 @@ class PoissonDistribution(ScipyDistribution):
         }
 
 
-@distribution(implements="core.unique_key", var_type="discrete", is_unique=True)
+@distclass(implements="core.unique_key", var_type="discrete", is_unique=True)
 class UniqueKeyDistribution(ScipyDistribution):
     """Integer distribution with unique keys.
 

--- a/metasynth/distribution/discrete.py
+++ b/metasynth/distribution/discrete.py
@@ -5,11 +5,11 @@ from typing import Set
 import numpy as np
 from scipy.stats import poisson, randint
 
-from metasynth.distribution.base import (distclass,
+from metasynth.distribution.base import (metadist,
                                          ScipyDistribution)
 
 
-@distclass(implements="core.discrete_uniform", var_type="discrete")
+@metadist(implements="core.discrete_uniform", var_type="discrete")
 class DiscreteUniformDistribution(ScipyDistribution):
     """Integer uniform distribution.
 
@@ -50,7 +50,7 @@ class DiscreteUniformDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.poisson", var_type="discrete")
+@metadist(implements="core.poisson", var_type="discrete")
 class PoissonDistribution(ScipyDistribution):
     """Poisson distribution."""
 
@@ -78,7 +78,7 @@ class PoissonDistribution(ScipyDistribution):
         }
 
 
-@distclass(implements="core.unique_key", var_type="discrete", is_unique=True)
+@metadist(implements="core.unique_key", var_type="discrete", is_unique=True)
 class UniqueKeyDistribution(ScipyDistribution):
     """Integer distribution with unique keys.
 

--- a/metasynth/distribution/faker.py
+++ b/metasynth/distribution/faker.py
@@ -3,10 +3,10 @@ from typing import Iterable
 
 from faker import Faker
 
-from metasynth.distribution.base import distclass, BaseDistribution
+from metasynth.distribution.base import metadist, BaseDistribution
 
 
-@distclass(implements="core.faker", var_type="string")
+@metadist(implements="core.faker", var_type="string")
 class FakerDistribution(BaseDistribution):
     """Distribution for the faker package.
 

--- a/metasynth/distribution/faker.py
+++ b/metasynth/distribution/faker.py
@@ -3,10 +3,11 @@ from typing import Iterable
 
 from faker import Faker
 
-from metasynth.distribution.base import CoreDistribution, StringDistribution
+from metasynth.distribution.base import distribution, BaseDistribution
 
 
-class FakerDistribution(CoreDistribution, StringDistribution):
+@distribution(implements="core.faker", var_type="string")
+class FakerDistribution(BaseDistribution):
     """Distribution for the faker package.
 
     This is mainly an interface for the faker package, so that it
@@ -21,8 +22,6 @@ class FakerDistribution(CoreDistribution, StringDistribution):
     locale: str
         Locale used for the faker package.
     """
-
-    implements = "core.faker"
 
     def __init__(self, faker_type: str, locale: str = "en_US"):
         self.faker_type: str = faker_type

--- a/metasynth/distribution/faker.py
+++ b/metasynth/distribution/faker.py
@@ -3,10 +3,10 @@ from typing import Iterable
 
 from faker import Faker
 
-from metasynth.distribution.base import distribution, BaseDistribution
+from metasynth.distribution.base import distclass, BaseDistribution
 
 
-@distribution(implements="core.faker", var_type="string")
+@distclass(implements="core.faker", var_type="string")
 class FakerDistribution(BaseDistribution):
     """Distribution for the faker package.
 

--- a/metasynth/distribution/regex/base.py
+++ b/metasynth/distribution/regex/base.py
@@ -6,7 +6,7 @@ from typing import List, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
 
-from metasynth.distribution.base import distclass, BaseDistribution
+from metasynth.distribution.base import metadist, BaseDistribution
 from metasynth.distribution.regex.element import (AlphaNumericRegex, AnyRegex,
                                                   BaseRegexElement, DigitRegex,
                                                   LettersRegex, LowercaseRegex,
@@ -37,7 +37,7 @@ def _get_gradient_start(values: Sequence[str], new_values: Sequence[str],
     return delta_energy/energy_budget
 
 
-@distclass(implements="core.regex", var_type="string")
+@metadist(implements="core.regex", var_type="string")
 class RegexDistribution(BaseDistribution):
     """Distribution that uses a strategy similar to regex.
 
@@ -184,7 +184,7 @@ class RegexDistribution(BaseDistribution):
         return cls([(r"\d{3,4}", 0.67)])
 
 
-@distclass(implements="core.unique_regex", var_type="string", is_unique=True)
+@metadist(implements="core.unique_regex", var_type="string", is_unique=True)
 class UniqueRegexDistribution(RegexDistribution):
     """Unique variant of the regex distribution.
 

--- a/metasynth/distribution/regex/base.py
+++ b/metasynth/distribution/regex/base.py
@@ -6,7 +6,7 @@ from typing import List, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
 
-from metasynth.distribution.base import distribution, BaseDistribution
+from metasynth.distribution.base import distclass, BaseDistribution
 from metasynth.distribution.regex.element import (AlphaNumericRegex, AnyRegex,
                                                   BaseRegexElement, DigitRegex,
                                                   LettersRegex, LowercaseRegex,
@@ -37,7 +37,7 @@ def _get_gradient_start(values: Sequence[str], new_values: Sequence[str],
     return delta_energy/energy_budget
 
 
-@distribution(implements="core.regex", var_type="string")
+@distclass(implements="core.regex", var_type="string")
 class RegexDistribution(BaseDistribution):
     """Distribution that uses a strategy similar to regex.
 
@@ -184,8 +184,7 @@ class RegexDistribution(BaseDistribution):
         return cls([(r"\d{3,4}", 0.67)])
 
 
-@distribution(implements="core.unique_regex", var_type="string",
-              is_unique=True)
+@distclass(implements="core.unique_regex", var_type="string", is_unique=True)
 class UniqueRegexDistribution(RegexDistribution):
     """Unique variant of the regex distribution.
 

--- a/metasynth/distribution/regex/base.py
+++ b/metasynth/distribution/regex/base.py
@@ -6,7 +6,7 @@ from typing import List, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
 
-from metasynth.distribution.base import CoreDistribution, StringDistribution
+from metasynth.distribution.base import distribution, BaseDistribution
 from metasynth.distribution.regex.element import (AlphaNumericRegex, AnyRegex,
                                                   BaseRegexElement, DigitRegex,
                                                   LettersRegex, LowercaseRegex,
@@ -37,7 +37,8 @@ def _get_gradient_start(values: Sequence[str], new_values: Sequence[str],
     return delta_energy/energy_budget
 
 
-class RegexDistribution(CoreDistribution, StringDistribution):
+@distribution(implements="core.regex", var_type="string")
+class RegexDistribution(BaseDistribution):
     """Distribution that uses a strategy similar to regex.
 
     The idea behind this method is that for structured strings
@@ -183,7 +184,9 @@ class RegexDistribution(CoreDistribution, StringDistribution):
         return cls([(r"\d{3,4}", 0.67)])
 
 
-class UniqueRegexDistribution(RegexDistribution, CoreDistribution):
+@distribution(implements="core.unique_regex", var_type="string",
+              is_unique=True)
+class UniqueRegexDistribution(RegexDistribution):
     """Unique variant of the regex distribution.
 
     Same as the normal regex distribution, but checks whether a key
@@ -194,9 +197,6 @@ class UniqueRegexDistribution(RegexDistribution, CoreDistribution):
     re_list: list of BaseRegexElement
         List of basic regex elements in the order that they occur.
     """
-
-    implements = "core.unique_regex"
-    is_unique = True
 
     def __init__(self, re_list: Sequence[Union[BaseRegexElement, Tuple[str, float]]]):
         super().__init__(re_list)


### PR DESCRIPTION
This PR converts some of the inheritance to a property to set class methods. No changes for users. User distributions should be easier to implemented now.

Fixes #95 