### PR TITLE
Fix misprop range

### DIFF
--- a/metasynth/var.py
+++ b/metasynth/var.py
@@ -72,6 +72,9 @@ class MetaVar():
         if self.prop_missing is None:
             raise ValueError(f"Error while initializing variable {self.name}."
                              " prop_missing is None.")
+        if self.prop_missing < -1e-8 or self.prop_missing > 1+1e-8:
+            raise ValueError(f"Cannot create variable '{self.name}' with proportion missing "
+                             "outside range [0, 1]")
 
     @classmethod
     def detect(cls, series_or_dataframe: Union[pd.Series, pl.Series, pl.DataFrame],

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -153,6 +153,17 @@ def test_bool(tmp_path, series_type):
 
 
 @mark.parametrize(
+    "prop_missing",
+    [-1, -0.1, 1.2],
+)
+def test_invalid_prop(prop_missing):
+    with raises(ValueError):
+        MetaVar("continuous")
+    with raises(ValueError):
+        MetaVar("continuous", prop_missing=prop_missing)
+
+
+@mark.parametrize(
     "dataframe",
     [
         pd.DataFrame({


### PR DESCRIPTION
Ensure that error messages get thrown when the missing proportion is outside [0, 1].

Fixes #105 