### PR TITLE
First version of CLI

### DIFF
--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -2,6 +2,7 @@
 import argparse
 import pathlib
 import pickle
+import sys
 
 from metasynth._version import __version__
 from metasynth import MetaFrame
@@ -12,6 +13,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog="metasynth",
         description="Synthesize data from Generative Metadata Format .json file.",
+        usage="%(prog)s synthesize [options] input output"
     )
     parser.add_argument(
         "input",
@@ -43,6 +45,12 @@ def main():
         version=f"%(prog)s {__version__}",
     )
 
+    # pop the shim subcommand and check that it is "synthesize"
+    subcommand = sys.argv.pop(1)
+    if subcommand != "synthesize":
+        parser.error(f"Invalid subcommand ({subcommand}).")
+
+    # parse the args without the shim subcommand
     args, _ = parser.parse_known_args()
 
     if not args.preview and not args.output:

--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -7,6 +7,7 @@ import sys
 from metasynth._version import __version__
 from metasynth import MetaFrame
 
+
 def main():
     """Parse arguments and generate synthetic data."""
     parser = argparse.ArgumentParser(
@@ -24,7 +25,7 @@ def main():
         type=pathlib.Path
     )
     parser.add_argument(
-        "-n", 
+        "-n",
         "--num_rows",
         help="Number of rows to synthesize",
         default=None,

--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -49,39 +49,38 @@ def main():
 
     print(args)
     # Create the metaframe from the json file
-    mf = MetaFrame.from_json(args.input)
+    meta_frame = MetaFrame.from_json(args.input)
 
     if args.print_only:
         # only print one row and exit
-        print(mf.synthesize(1))
+        print(meta_frame.synthesize(1))
         sys.exit(0)
 
     # Generate a data frame
     if args.num_rows is not None:
-        df = mf.synthesize(args.num_rows)
+        data_frame = meta_frame.synthesize(args.num_rows)
     else:
-        df = mf.synthesize(mf.n_rows)
+        data_frame = meta_frame.synthesize(meta_frame.n_rows)
 
     # Store the dataframe to file
-    match args.output.suffix:
-        case ".csv":
-            df.write_csv(args.output)
-        case ".feather":
-            df.write_ipc(args.output)
-        case ".parquet":
-            df.write_parquet(args.output)
-        case ".xlsx":
-            df.write_excel(args.output)
-        case ".pkl":
-            with open(args.output, "wb") as f:
-                pickle.dump(df, file=f)
-                f.close()
-        case _:
-            print(
-                f"Output file format ({args.output.suffix}) incorrect.",
-                "Use .csv, .feather, .parquet, .pkl, or .xlsx."
-            )
-            sys.exit(1)
+    if args.output.suffix == ".csv":
+        data_frame.write_csv(args.output)
+    elif args.output.suffix == ".feather":
+        data_frame.write_ipc(args.output)
+    elif args.output.suffix == ".parquet":
+        data_frame.write_parquet(args.output)
+    elif args.output.suffix == ".xlsx":
+        data_frame.write_excel(args.output)
+    elif args.output.suffix == ".pkl":
+        with open(args.output, "wb") as pkl_file:
+            pickle.dump(data_frame, file=pkl_file)
+            pkl_file.close()
+    else:
+        print(
+            f"Output file format ({args.output.suffix}) incorrect.",
+            "Use .csv, .feather, .parquet, .pkl, or .xlsx."
+        )
+        sys.exit(1)
     sys.exit(0)
 
 

--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -1,0 +1,88 @@
+"""CLI for generating synthetic data frames from a metasynth .json file."""
+import argparse
+import pathlib
+import pickle
+import sys
+
+from metasynth._version import __version__
+from metasynth import MetaFrame
+
+def main():
+    """Parse arguments and generate synthetic data."""
+    parser = argparse.ArgumentParser(
+        prog="metasynth",
+        description="Synthesize data from Generative Metadata Format .json file.",
+    )
+    parser.add_argument(
+        "input",
+        help="Input file.",
+        type=pathlib.Path
+    )
+    parser.add_argument(
+        "output",
+        help="Output file. File extension should be one of: .csv, .feather, .parquet, .pkl, .xlsx",
+        type=pathlib.Path
+    )
+    parser.add_argument(
+        "-n", 
+        "--num_rows",
+        help="Number of rows to synthesize",
+        default=None,
+        type=int,
+        required=False
+    )
+    parser.add_argument(
+        "-p", "--print_only",
+        help="print one-row data frame to console and exit",
+        action="store_true"
+    )
+    # version
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+
+    args, _ = parser.parse_known_args()
+
+    print(args)
+    # Create the metaframe from the json file
+    mf = MetaFrame.from_json(args.input)
+
+    if args.print_only:
+        # only print one row and exit
+        print(mf.synthesize(1))
+        sys.exit(0)
+
+    # Generate a data frame
+    if args.num_rows is not None:
+        df = mf.synthesize(args.num_rows)
+    else:
+        df = mf.synthesize(mf.n_rows)
+
+    # Store the dataframe to file
+    match args.output.suffix:
+        case ".csv":
+            df.write_csv(args.output)
+        case ".feather":
+            df.write_ipc(args.output)
+        case ".parquet":
+            df.write_parquet(args.output)
+        case ".xlsx":
+            df.write_excel(args.output)
+        case ".pkl":
+            with open(args.output, "wb") as f:
+                pickle.dump(df, file=f)
+                f.close()
+        case _:
+            print(
+                f"Output file format ({args.output.suffix}) incorrect.",
+                "Use .csv, .feather, .parquet, .pkl, or .xlsx."
+            )
+            sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -16,44 +16,45 @@ def main():
     )
     parser.add_argument(
         "input",
-        help="Input file.",
+        help="input file; typically .json adhering to the Generative Metadata Format",
         type=pathlib.Path
     )
     parser.add_argument(
         "output",
-        help="Output file. File extension should be one of: .csv, .feather, .parquet, .pkl, .xlsx",
+        help="output file (.csv, .feather, .parquet, .pkl, or .xlsx)",
+        nargs="?",
         type=pathlib.Path
     )
     parser.add_argument(
-        "-n",
-        "--num_rows",
-        help="Number of rows to synthesize",
+        "-n", "--num_rows",
+        help="number of rows to synthesize",
         default=None,
         type=int,
         required=False
     )
     parser.add_argument(
         "-p", "--print_only",
-        help="print one-row data frame to console and exit",
+        help="print six-row data frame to console and exit",
         action="store_true"
     )
     # version
     parser.add_argument(
-        "-v",
-        "--version",
+        "-v", "--version",
         action="version",
         version=f"%(prog)s {__version__}",
     )
 
     args, _ = parser.parse_known_args()
 
-    print(args)
+    if not args.print_only and not args.output:
+        parser.error("Output file is required.")
+
     # Create the metaframe from the json file
     meta_frame = MetaFrame.from_json(args.input)
 
     if args.print_only:
-        # only print one row and exit
-        print(meta_frame.synthesize(1))
+        # only print six rows and exit
+        print(meta_frame.synthesize(6))
         sys.exit(0)
 
     # Generate a data frame
@@ -76,11 +77,10 @@ def main():
             pickle.dump(data_frame, file=pkl_file)
             pkl_file.close()
     else:
-        print(
-            f"Output file format ({args.output.suffix}) incorrect.",
+        parser.error(
+            f"Output file format ({args.output.suffix}) incorrect." +
             "Use .csv, .feather, .parquet, .pkl, or .xlsx."
         )
-        sys.exit(1)
     sys.exit(0)
 
 

--- a/metasynth/__main__.py
+++ b/metasynth/__main__.py
@@ -2,7 +2,6 @@
 import argparse
 import pathlib
 import pickle
-import sys
 
 from metasynth._version import __version__
 from metasynth import MetaFrame
@@ -33,8 +32,8 @@ def main():
         required=False
     )
     parser.add_argument(
-        "-p", "--print_only",
-        help="print six-row data frame to console and exit",
+        "-p", "--preview",
+        help="preview six-row synthesized data frame in console and exit",
         action="store_true"
     )
     # version
@@ -46,16 +45,16 @@ def main():
 
     args, _ = parser.parse_known_args()
 
-    if not args.print_only and not args.output:
+    if not args.preview and not args.output:
         parser.error("Output file is required.")
 
     # Create the metaframe from the json file
     meta_frame = MetaFrame.from_json(args.input)
 
-    if args.print_only:
+    if args.preview:
         # only print six rows and exit
         print(meta_frame.synthesize(6))
-        sys.exit(0)
+        return
 
     # Generate a data frame
     if args.num_rows is not None:
@@ -75,13 +74,11 @@ def main():
     elif args.output.suffix == ".pkl":
         with open(args.output, "wb") as pkl_file:
             pickle.dump(data_frame, file=pkl_file)
-            pkl_file.close()
     else:
         parser.error(
-            f"Output file format ({args.output.suffix}) incorrect." +
+            f"Unsupported output file format ({args.output.suffix})." +
             "Use .csv, .feather, .parquet, .pkl, or .xlsx."
         )
-    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
 ]
 
 dependencies = [
-	"pandas",
-	"polars>=0.14.17",
-	"numpy>=1.20",
+    "pandas",
+    "polars>=0.14.17",
+    "numpy>=1.20",
     "pyarrow",  # Dependency of polars since we're converting from pandas.
     "scipy",
     "numpy>=1.20",
@@ -46,8 +46,8 @@ documentation = "https://metasynth.readthedocs.io/en/latest/index.html"
 
 [project.optional-dependencies]
 test = [
-	"pytest", "pylint", "pydocstyle", "mypy", "flake8", "nbval",
-	"sphinx<7.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon", 
+    "pytest", "pylint", "pydocstyle", "mypy", "flake8", "nbval",
+    "sphinx<7.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon", 
     "sphinx-autodoc-typehints", "sphinx_inline_tabs", "sphinx_copybutton",
     "XlsxWriter"
 ]
@@ -66,13 +66,13 @@ write_to = "metasynth/_version.py"
 
 [[tool.mypy.overrides]]
 module = [
-	"scipy.*",
-	"pandas.*",
-	"jsonschema.*",
-	"sklearn.*",
-	"importlib_metadata.*",
-	"importlib_resources.*",
-	"wget.*",
+    "scipy.*",
+    "pandas.*",
+    "jsonschema.*",
+    "sklearn.*",
+    "importlib_metadata.*",
+    "importlib_resources.*",
+    "wget.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ test = [
 	"sphinx<7.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon", "sphinx-autodoc-typehints", "sphinx_inline_tabs", "sphinx_copybutton"
 ]
 
+[project.scripts]
+metasynth = "metasynth.__main__:main"
+
 [project.entry-points."metasynth.distribution_provider"]
 builtin = "metasynth.provider:BuiltinDistributionProvider"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ documentation = "https://metasynth.readthedocs.io/en/latest/index.html"
 [project.optional-dependencies]
 test = [
 	"pytest", "pylint", "pydocstyle", "mypy", "flake8", "nbval",
-	"sphinx<7.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon", "sphinx-autodoc-typehints", "sphinx_inline_tabs", "sphinx_copybutton"
+	"sphinx<7.0.0", "sphinx-rtd-theme", "sphinxcontrib-napoleon", 
+    "sphinx-autodoc-typehints", "sphinx_inline_tabs", "sphinx_copybutton",
+    "XlsxWriter"
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ def tmp_dir(tmp_path_factory) -> Path:
 def test_cli(tmp_dir, ext):
     """A simple integration test for reading and writing using the CLI"""
     input_file = tmp_dir / "titanic.json"
-    output_file = tmp_dir / f"titanic.{ext}"
+    output_file = tmp_dir / f"titanic{ext}"
 
     # Run the cli with different extensions
     result = subprocess.run(f"metasynth -n 25 {input_file} {output_file}", check=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,6 @@ def test_cli(tmp_dir, ext):
     output_file = tmp_dir / f"titanic{ext}"
 
     # Run the cli with different extensions
-    result = subprocess.run(f"metasynth -n 25 {input_file} {output_file}", check=False)
+    result = subprocess.run(["metasynth", "-n 25", input_file, output_file], check=False)
     assert result.returncode == 0
     assert output_file.is_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,7 @@ def test_cli(tmp_dir, ext):
     cmd = [
         Path(sys.executable).resolve(),   # the python executable
         Path("metasynth", "__main__.py"), # the cli script
+        "synthesize",                     # the subcommand
         "-n 25",                          # only generate 25 samples
         tmp_dir / "titanic.json",         # the input file
         out_file                          # the output file

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+from pytest import mark, fixture
+import polars as pl
+from metasynth import MetaFrame
+
+TMP_DIR_PATH = None
+
+@fixture(scope="module")
+def tmp_dir(tmp_path_factory) -> Path:
+    global TMP_DIR_PATH
+    if TMP_DIR_PATH is None:
+        # Create a temporary input file
+        TMP_DIR_PATH = tmp_path_factory.mktemp("data")
+        json_path = TMP_DIR_PATH / "titanic.json"
+        csv_fp = Path("tests", "data", "titanic.csv")
+        csv_dt = {
+            "PassengerId": pl.Int64,
+            "Survived": pl.Categorical,
+            "Pclass": pl.Categorical,
+            "Name": str,
+            "Sex": pl.Categorical,
+            "SibSp": pl.Categorical,
+            "Parch": pl.Categorical,
+            "Ticket": str,
+            "Cabin": str,
+            "Embarked": pl.Categorical,
+            "Age": float,
+            "Fare": float
+        }
+        data_frame = pl.read_csv(csv_fp, dtypes=csv_dt)[:100]
+        meta_frame = MetaFrame.fit_dataframe(data_frame, spec={"PassengerId": {"unique": True}})
+        meta_frame.to_json(json_path)
+    return TMP_DIR_PATH
+
+@mark.parametrize("ext", [".csv", ".feather", ".parquet", ".pkl", ".xlsx"])
+def test_cli(tmp_dir, ext):
+    """A simple integration test for reading and writing using the CLI"""
+    input_file = tmp_dir / "titanic.json"
+    output_file = tmp_dir / f"titanic.{ext}"
+
+    # Run the cli with different extensions
+    result = subprocess.run(f"metasynth -n 25 {input_file} {output_file}", check=False)
+    assert result.returncode == 0
+    assert output_file.is_file()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 from pathlib import Path
 from pytest import mark, fixture
@@ -36,10 +37,20 @@ def tmp_dir(tmp_path_factory) -> Path:
 @mark.parametrize("ext", [".csv", ".feather", ".parquet", ".pkl", ".xlsx"])
 def test_cli(tmp_dir, ext):
     """A simple integration test for reading and writing using the CLI"""
-    input_file = tmp_dir / "titanic.json"
-    output_file = tmp_dir / f"titanic{ext}"
+    
+    # create out file path with correct extension
+    out_file = tmp_dir / f"titanic{ext}"
+
+    # create command to run in subprocess with arguments
+    cmd = [
+        Path(sys.executable).resolve(),   # the python executable
+        Path("metasynth", "__main__.py"), # the cli script
+        "-n 25",                          # only generate 25 samples
+        tmp_dir / "titanic.json",         # the input file
+        out_file                          # the output file
+    ]
 
     # Run the cli with different extensions
-    result = subprocess.run(["metasynth", "-n 25", input_file, output_file], check=False)
+    result = subprocess.run(cmd, check=False)
     assert result.returncode == 0
-    assert output_file.is_file()
+    assert out_file.is_file()


### PR DESCRIPTION
Added a command line interface, with the following help file:

```
usage: metasynth [-h] [-n NUM_ROWS] [-p] [-v] input output

Synthesize data from Generative Metadata Format .json file.

positional arguments:
  input                 Input file.
  output                Output file. File extension should be one of: .csv, .feather, .parquet, .pkl, .xlsx

options:
  -h, --help            show this help message and exit
  -n NUM_ROWS, --num_rows NUM_ROWS
                        Number of rows to synthesize
  -p, --print_only      print one-row data frame to console and exit
  -v, --version         show program's version number and exit
```

This will pave the way for stable, versioned docker containers which directly use this CLI, e.g., 
```docker
docker sodascience/metasynth:v0.4 metatdatafile.json outputfile.csv
```
Those containers could be automatically built whenever we release on GitHub as part of our CI