### PR TITLE
fixed categorical and faker dists not being in line with new formatted print methods

### DIFF
--- a/metasynth/distribution/categorical.py
+++ b/metasynth/distribution/categorical.py
@@ -54,9 +54,6 @@ class MultinoulliDistribution(BaseDistribution):
             "probs": {"type": "array", "items": {"type": "number"}},
         }
 
-    def __str__(self):
-        return str(self.to_dict())
-
     def draw(self):
         return str(np.random.choice(self.labels, p=self.probs))
 

--- a/metasynth/distribution/faker.py
+++ b/metasynth/distribution/faker.py
@@ -34,9 +34,6 @@ class FakerDistribution(BaseDistribution):
         """Select the appropriate faker function and locale."""
         return cls(faker_type, locale)
 
-    def __str__(self):
-        return f"faker.{self.faker_type}.{self.locale}"
-
     def draw(self):
         return getattr(self.fake, self.faker_type)()
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -24,7 +24,7 @@ def test_util(dist_str, dist):
     provider_list = DistributionProviderList("builtin")
     dist_class = provider_list.find_distribution(dist_str)
     assert dist == dist_class
-    if dist_str.startswith("faker"):
+    if "faker" in dist_str:
         with raises(ValueError):
             provider_list.find_distribution("this is not a distribution")
     new_class = provider_list.find_distribution(dist_class.__name__)

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -10,6 +10,6 @@ def test_faker(series_type):
     var = FakerDistribution.fit(series_type([1, 2, 3]))
     assert isinstance(var.to_dict(), dict)
     assert isinstance(var.draw(), str)
-    assert str(var).startswith("faker")
+    assert 'faker' in str(var)
     assert var.locale == "en_US"
     assert var.faker_type == "city"


### PR DESCRIPTION
Every distribution now SHOULD print the same, this solves #125.

Tests for faker have been updated accordingly.