### PR TITLE
Modernize the dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!pyproject.toml
+!metasyn/
+!.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # use the slim python image 
-FROM python:3.11-slim
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # Install system dependencies
 # git is used by versioneer to define the project version
@@ -7,7 +9,7 @@ RUN apt update && apt install -y git
 
 # Install metasyn
 COPY . metasyn/
-RUN pip install ./metasyn[extra]
+RUN pip install ./metasyn[extra] --no-compile --no-cache-dir
 
 # Remove metasyn folder
 RUN rm -r metasyn/


### PR DESCRIPTION
- update to 3.13
- add dockerignore for much smaller size
- add --no-compile and --no-cache-dir to pip call