### PR TITLE
Set specific version of setuptools for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools-scm[toml]>=6.2"]
+requires = ["setuptools==75.8.0", "setuptools-scm[toml]>=6.2"] # metadata-version = "2.2" for pypi
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Otherwise release does not work. We need Metadata-Version: 2.2