### PR TITLE
Remove some sources of None

### DIFF
--- a/metasyn/distribution/freetext.py
+++ b/metasyn/distribution/freetext.py
@@ -41,7 +41,7 @@ class FreeTextDistribution(BaseDistribution):
 
     """
 
-    def __init__(self, locale: str, avg_sentences: Optional[float], avg_words: float):
+    def __init__(self, locale: str, avg_sentences: float, avg_words: float):
         self.locale: str = locale
         self.avg_sentences = avg_sentences
         self.avg_words = avg_words
@@ -49,7 +49,7 @@ class FreeTextDistribution(BaseDistribution):
 
 
     def draw(self):
-        if self.avg_sentences is None:
+        if self.avg_sentences is None or self.avg_sentences < 0.01:
             n_words = max(1, poisson(self.avg_words).rvs())
             sentence = self.fake.sentence(n_words)
             return sentence[:-1]
@@ -110,7 +110,7 @@ class FreeTextFitter(BaseFitter):
         n_punctuation = len(list(PUNCTUATION.finditer(all_text)))
         n_words = len(list(LETTERS.finditer(all_text)))
         if n_punctuation < n_non_empty//3:
-            avg_sentence = None
+            avg_sentence = 0.0
         else:
             avg_sentence = n_punctuation/len(series)
         avg_words = n_words/len(series)

--- a/metasyn/file.py
+++ b/metasyn/file.py
@@ -327,10 +327,13 @@ class SavFileInterface(ReadStatInterface):
             "variable_format": prs_metadata.original_variable_types,
             "compress": compress,
             "variable_display_width": prs_metadata.variable_display_width,
-            "file_label": prs_metadata.file_label,
             "variable_value_labels": prs_metadata.variable_value_labels,
             "variable_measure": prs_metadata.variable_measure,
         }
+        # Workaround for TOML files that don't like None values.
+        if prs_metadata.file_label is not None:
+            metadata["file_label"] = prs_metadata.file_label
+
         return metadata
 
 
@@ -378,9 +381,12 @@ class StataFileInterface(ReadStatInterface):
         metadata = {
             "column_labels": prs_metadata.column_labels,
             "variable_format": prs_metadata.original_variable_types,
-            "file_label": prs_metadata.file_label,
             "variable_value_labels": prs_metadata.variable_value_labels,
         }
+        # Workaround for TOML files that don't like None values.
+        if prs_metadata.file_label is not None:
+            metadata["file_label"] = prs_metadata.file_label
+
         return metadata
 
     def _prep_df_for_writing(self, df):

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -30,9 +30,9 @@ def test_faker(series_type):
     "series,lang,avg_sentences,avg_words", [
             (pl.Series(
                 ["hotdog", "mother", "yes", "tip", "crate",
-                 "sink", "dark", "crossbar", "toilet", "grow", "patient"]), "EN", None, 1),
+                 "sink", "dark", "crossbar", "toilet", "grow", "patient"]), "EN", 0.0, 1),
             (pl.Series(["hotdog mother", "yes tip", "crate sink", "dark crossbar", "toilet grow",
-                        "patient is"]), "EN", None, 2),
+                        "patient is"]), "EN", 0.0, 2),
             (pl.Series(["hotdog mother.", "yes tip.", "crate sink.", "dark crossbar.",
                         "toilet grow.", "patient is."]), "EN", 1, 2),
             (pl.Series(["gaat naar school. Ik ben benieuwd.", "Wat is vraag? Wanneer komt hij."]),


### PR DESCRIPTION
None values cause trouble with TOML files, since the TOML language doesn't recognize anything like a none or null value. Should remain backward compatibility with GMF files.