### PR TITLE
add hospital and druguse demo dataframes to documentation

### DIFF
--- a/metasyn/demo/dataset.py
+++ b/metasyn/demo/dataset.py
@@ -286,13 +286,16 @@ def _get_demo_class(name):
 def demo_file(name: str = "titanic") -> Path:
     """Get the path for a demo data file.
 
-    There are six options:
+    There are eight options:
         - titanic (Included in pandas, but post-processed to contain more columns)
         - spaceship (CC-BY from https://www.kaggle.com/competitions/spaceship-titanic)
         - synthea_imaging (CC-BY from https://synthea.mitre.org/downloads)
         - fruit (very basic example data from Polars)
         - survey (columns from ESS round 11 Human Values Scale questionnaire for the Netherlands)
         - test (columns with all supported data types)
+        - hospital (Example electronic health record hospital dataset)
+        - druguse (Example dataset with answers to an open question on study participants'
+          daily drug use)
 
     Arguments
     ---------
@@ -315,18 +318,21 @@ def demo_file(name: str = "titanic") -> Path:
 def demo_dataframe(name: str = "titanic") -> pl.DataFrame:
     """Get a demonstration dataset as a prepared polars dataframe.
 
-    There are six options:
+    There are eight options:
         - titanic (Included in pandas, but post-processed to contain more columns)
         - spaceship (CC-BY from https://www.kaggle.com/competitions/spaceship-titanic)
         - synthea_imaging (CC-BY from https://synthea.mitre.org/downloads)
         - fruit (very basic example data from Polars)
         - survey (columns from ESS round 11 Human Values Scale questionnaire for the Netherlands)
         - test (columns with all supported data types)
+        - hospital (Example electronic health record hospital dataset)
+        - druguse (Example dataset with answers to an open question on study participants'
+          daily drug use)
 
     Arguments
     ---------
     name:
-        Name of the demo dataset: spaceship, fruit, or titanic.
+        Name of the demo dataset.
 
     Returns
     -------


### PR DESCRIPTION
### Description

This PR resolves [Issue #417](https://github.com/sodascience/metasyn/issues/417) where the `hospital` and `druguse` demo dataframes were missing from the documentation.

It makes the following updates to [metasyn/demo/dataset.py](cci:7://file:///Users/parth/HomeFolder/temp/OpenContributions/metasyn/metasyn/demo/dataset.py:0:0-0:0):
- Updates the docstring for [demo_file()](cci:1://file:///Users/parth/HomeFolder/temp/OpenContributions/metasyn/metasyn/demo/dataset.py:285:0-314:46) to enumerate all 8 available internal datasets (adding the `hospital` and `druguse` options alongside their descriptions). 
- Updates the docstring for [demo_dataframe()](cci:1://file:///Users/parth/HomeFolder/temp/OpenContributions/metasyn/metasyn/demo/dataset.py:317:0-346:48) to correspondingly reflect the 8 datasets and adjusts the parameter argument breakdown to refer to the overall available dataset names rather than just three of them.

### Verification

- All local tests have been executed via `pytest` to confirm the synthesis mechanism for these datasets parses correctly according to schema mappings. Since [test_demo_datasets](cci:1://file:///Users/parth/HomeFolder/temp/OpenContributions/metasyn/tests/test_dataset.py:131:0-157:41) is parameterized over `_AVAILABLE_DATASETS` programmatically, the updated dataframes are covered automatically without introducing failures.
- All core [.github/workflows/core-ci.yml](cci:7://file:///Users/parth/HomeFolder/temp/OpenContributions/metasyn/.github/workflows/core-ci.yml:0:0-0:0) CI stages (`ruff check metasyn`, `mypy metasyn`, Code Coverage `>95%`, and examples) have successfully passed locally.

Closes #417
