### PR TITLE
Add fit log

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -306,7 +306,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████| 13/13 [00:04<00:00,  2.90it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████| 13/13 [00:04<00:00,  3.21it/s]\n"
      ]
     }
    ],
@@ -631,7 +631,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " PassengerId: 100%|██████████████████████████████████████| 13/13 [00:00<00:00, 497.04variables/s]\n"
+      " PassengerId: 100%|████████████████████████████████████████| 13/13 [00:00<00:00, 495.51variables/s]\n"
      ]
     }
    ],
@@ -674,7 +674,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Worry indeed. Many her.&quot;</td><td>&quot;female&quot;</td><td>12</td><td>0</td><td>&quot;40165&quot;</td><td>46.010577</td><td>null</td><td>&quot;S&quot;</td><td>1904-03-19</td><td>13:02:16</td><td>2022-07-26 20:09:30</td><td>null</td></tr><tr><td>2</td><td>&quot;Girl.&quot;</td><td>&quot;male&quot;</td><td>26</td><td>0</td><td>&quot;1640&quot;</td><td>3.357927</td><td>&quot;F97&quot;</td><td>&quot;S&quot;</td><td>1915-05-12</td><td>17:27:01</td><td>2022-07-17 07:33:55</td><td>null</td></tr><tr><td>3</td><td>&quot;Short measure. Size. My me do.…</td><td>&quot;male&quot;</td><td>null</td><td>0</td><td>&quot;301409&quot;</td><td>40.925071</td><td>null</td><td>&quot;S&quot;</td><td>1910-07-10</td><td>12:11:04</td><td>2022-08-04 01:54:25</td><td>null</td></tr><tr><td>4</td><td>&quot;Style. Network. Even.&quot;</td><td>&quot;male&quot;</td><td>21</td><td>0</td><td>&quot;030662&quot;</td><td>13.718745</td><td>null</td><td>&quot;S&quot;</td><td>1915-09-02</td><td>17:34:47</td><td>null</td><td>null</td></tr><tr><td>5</td><td>&quot;Rock. Strong.&quot;</td><td>&quot;male&quot;</td><td>55</td><td>1</td><td>&quot;08465&quot;</td><td>24.917343</td><td>null</td><td>&quot;S&quot;</td><td>1925-08-13</td><td>15:51:24</td><td>2022-07-15 15:03:07</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Miss. Each.&quot;</td><td>&quot;male&quot;</td><td>21</td><td>0</td><td>&quot;767334&quot;</td><td>12.790993</td><td>&quot;A05&quot;</td><td>&quot;S&quot;</td><td>1913-08-17</td><td>17:37:36</td><td>2022-07-30 02:36:48</td><td>null</td></tr><tr><td>2</td><td>&quot;Daughter. Enter. Individual. L…</td><td>&quot;male&quot;</td><td>4</td><td>0</td><td>&quot;2984&quot;</td><td>54.122974</td><td>null</td><td>&quot;Q&quot;</td><td>1909-06-15</td><td>11:33:47</td><td>2022-07-31 11:20:52</td><td>null</td></tr><tr><td>3</td><td>&quot;Entire.&quot;</td><td>&quot;male&quot;</td><td>null</td><td>0</td><td>&quot;882617&quot;</td><td>14.295391</td><td>null</td><td>&quot;C&quot;</td><td>1925-09-01</td><td>18:25:29</td><td>2022-08-09 18:50:35</td><td>null</td></tr><tr><td>4</td><td>&quot;Religious reality into. Owner …</td><td>&quot;female&quot;</td><td>39</td><td>0</td><td>&quot;8223&quot;</td><td>43.131226</td><td>null</td><td>&quot;C&quot;</td><td>1918-05-11</td><td>13:01:05</td><td>2022-07-18 06:03:53</td><td>null</td></tr><tr><td>5</td><td>&quot;Should while within partner cr…</td><td>&quot;male&quot;</td><td>24</td><td>0</td><td>&quot;7877&quot;</td><td>79.752251</td><td>null</td><td>&quot;S&quot;</td><td>1930-11-20</td><td>17:31:04</td><td>null</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 13)\n",
@@ -684,20 +684,21 @@
        "│ i64         ┆ str          ┆ cat    ┆ i64  ┆   ┆ date       ┆ time       ┆ ---          ┆ str    │\n",
        "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ datetime[μs] ┆        │\n",
        "╞═════════════╪══════════════╪════════╪══════╪═══╪════════════╪════════════╪══════════════╪════════╡\n",
-       "│ 1           ┆ Worry        ┆ female ┆ 12   ┆ … ┆ 1904-03-19 ┆ 13:02:16   ┆ 2022-07-26   ┆ null   │\n",
-       "│             ┆ indeed. Many ┆        ┆      ┆   ┆            ┆            ┆ 20:09:30     ┆        │\n",
-       "│             ┆ her.         ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│ 2           ┆ Girl.        ┆ male   ┆ 26   ┆ … ┆ 1915-05-12 ┆ 17:27:01   ┆ 2022-07-17   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 07:33:55     ┆        │\n",
-       "│ 3           ┆ Short        ┆ male   ┆ null ┆ … ┆ 1910-07-10 ┆ 12:11:04   ┆ 2022-08-04   ┆ null   │\n",
-       "│             ┆ measure.     ┆        ┆      ┆   ┆            ┆            ┆ 01:54:25     ┆        │\n",
-       "│             ┆ Size. My me  ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│             ┆ do.…         ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│ 4           ┆ Style.       ┆ male   ┆ 21   ┆ … ┆ 1915-09-02 ┆ 17:34:47   ┆ null         ┆ null   │\n",
-       "│             ┆ Network.     ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│             ┆ Even.        ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│ 5           ┆ Rock.        ┆ male   ┆ 55   ┆ … ┆ 1925-08-13 ┆ 15:51:24   ┆ 2022-07-15   ┆ null   │\n",
-       "│             ┆ Strong.      ┆        ┆      ┆   ┆            ┆            ┆ 15:03:07     ┆        │\n",
+       "│ 1           ┆ Miss. Each.  ┆ male   ┆ 21   ┆ … ┆ 1913-08-17 ┆ 17:37:36   ┆ 2022-07-30   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 02:36:48     ┆        │\n",
+       "│ 2           ┆ Daughter.    ┆ male   ┆ 4    ┆ … ┆ 1909-06-15 ┆ 11:33:47   ┆ 2022-07-31   ┆ null   │\n",
+       "│             ┆ Enter.       ┆        ┆      ┆   ┆            ┆            ┆ 11:20:52     ┆        │\n",
+       "│             ┆ Individual.  ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│             ┆ L…           ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│ 3           ┆ Entire.      ┆ male   ┆ null ┆ … ┆ 1925-09-01 ┆ 18:25:29   ┆ 2022-08-09   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 18:50:35     ┆        │\n",
+       "│ 4           ┆ Religious    ┆ female ┆ 39   ┆ … ┆ 1918-05-11 ┆ 13:01:05   ┆ 2022-07-18   ┆ null   │\n",
+       "│             ┆ reality      ┆        ┆      ┆   ┆            ┆            ┆ 06:03:53     ┆        │\n",
+       "│             ┆ into. Owner  ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│             ┆ …            ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│ 5           ┆ Should while ┆ male   ┆ 24   ┆ … ┆ 1930-11-20 ┆ 17:31:04   ┆ null         ┆ null   │\n",
+       "│             ┆ within       ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│             ┆ partner cr…  ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
        "└─────────────┴──────────────┴────────┴──────┴───┴────────────┴────────────┴──────────────┴────────┘"
       ]
      },
@@ -761,8 +762,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████| 13/13 [00:02<00:00,  5.81it/s]\n",
-      " PassengerId: 100%|██████████████████████████████████████| 13/13 [00:00<00:00, 752.34variables/s]\n"
+      "100%|██████████████████████████████████████████████████████████████| 13/13 [00:02<00:00,  5.52it/s]\n",
+      " PassengerId: 100%|████████████████████████████████████████| 13/13 [00:00<00:00, 812.57variables/s]\n"
      ]
     },
     {
@@ -775,7 +776,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Brett Wells&quot;</td><td>&quot;male&quot;</td><td>37</td><td>0</td><td>&quot;3971&quot;</td><td>0.385079</td><td>&quot;B877&quot;</td><td>&quot;S&quot;</td><td>1920-10-06</td><td>14:26:40</td><td>2022-07-30 19:40:19</td><td>null</td></tr><tr><td>2</td><td>&quot;George Dalton&quot;</td><td>&quot;female&quot;</td><td>39</td><td>0</td><td>&quot;68777&quot;</td><td>12.072327</td><td>null</td><td>&quot;S&quot;</td><td>1935-05-14</td><td>18:37:11</td><td>2022-08-15 02:48:21</td><td>null</td></tr><tr><td>3</td><td>&quot;Jennifer Lucas&quot;</td><td>&quot;male&quot;</td><td>7</td><td>0</td><td>&quot;1715&quot;</td><td>4.515465</td><td>null</td><td>&quot;S&quot;</td><td>1919-03-16</td><td>11:42:46</td><td>2022-08-14 13:16:38</td><td>null</td></tr><tr><td>4</td><td>&quot;Anthony Foster&quot;</td><td>&quot;female&quot;</td><td>null</td><td>0</td><td>&quot;94207&quot;</td><td>57.769245</td><td>null</td><td>&quot;S&quot;</td><td>1937-05-22</td><td>13:20:34</td><td>2022-08-06 00:08:05</td><td>null</td></tr><tr><td>5</td><td>&quot;Kevin Mitchell&quot;</td><td>&quot;female&quot;</td><td>28</td><td>1</td><td>&quot;HDCV 77808&quot;</td><td>17.991418</td><td>null</td><td>&quot;S&quot;</td><td>1932-02-09</td><td>11:39:22</td><td>null</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Kevin Martinez&quot;</td><td>&quot;male&quot;</td><td>53</td><td>0</td><td>&quot;4007&quot;</td><td>16.563083</td><td>null</td><td>&quot;S&quot;</td><td>1916-12-07</td><td>11:34:40</td><td>2022-07-25 01:03:01</td><td>null</td></tr><tr><td>2</td><td>&quot;Julia Gray&quot;</td><td>&quot;male&quot;</td><td>49</td><td>0</td><td>&quot;1904&quot;</td><td>4.599676</td><td>null</td><td>&quot;S&quot;</td><td>1939-12-30</td><td>12:21:49</td><td>null</td><td>null</td></tr><tr><td>3</td><td>&quot;James Rogers&quot;</td><td>&quot;male&quot;</td><td>null</td><td>0</td><td>&quot;5196&quot;</td><td>60.776063</td><td>&quot;F2&quot;</td><td>&quot;S&quot;</td><td>1936-11-04</td><td>13:59:05</td><td>2022-07-31 22:42:29</td><td>null</td></tr><tr><td>4</td><td>&quot;Jennifer Johnson MD&quot;</td><td>&quot;female&quot;</td><td>30</td><td>0</td><td>&quot;9753&quot;</td><td>35.378696</td><td>null</td><td>&quot;S&quot;</td><td>1905-11-11</td><td>16:15:25</td><td>2022-08-10 16:44:09</td><td>null</td></tr><tr><td>5</td><td>&quot;Aaron Herrera&quot;</td><td>&quot;male&quot;</td><td>28</td><td>0</td><td>&quot;1042&quot;</td><td>53.755765</td><td>null</td><td>&quot;Q&quot;</td><td>1920-01-29</td><td>10:44:21</td><td>2022-08-10 03:17:41</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 13)\n",
@@ -785,16 +786,15 @@
        "│ i64         ┆ str          ┆ cat    ┆ i64  ┆   ┆ date       ┆ time       ┆ ---          ┆ str    │\n",
        "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ datetime[μs] ┆        │\n",
        "╞═════════════╪══════════════╪════════╪══════╪═══╪════════════╪════════════╪══════════════╪════════╡\n",
-       "│ 1           ┆ Brett Wells  ┆ male   ┆ 37   ┆ … ┆ 1920-10-06 ┆ 14:26:40   ┆ 2022-07-30   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 19:40:19     ┆        │\n",
-       "│ 2           ┆ George       ┆ female ┆ 39   ┆ … ┆ 1935-05-14 ┆ 18:37:11   ┆ 2022-08-15   ┆ null   │\n",
-       "│             ┆ Dalton       ┆        ┆      ┆   ┆            ┆            ┆ 02:48:21     ┆        │\n",
-       "│ 3           ┆ Jennifer     ┆ male   ┆ 7    ┆ … ┆ 1919-03-16 ┆ 11:42:46   ┆ 2022-08-14   ┆ null   │\n",
-       "│             ┆ Lucas        ┆        ┆      ┆   ┆            ┆            ┆ 13:16:38     ┆        │\n",
-       "│ 4           ┆ Anthony      ┆ female ┆ null ┆ … ┆ 1937-05-22 ┆ 13:20:34   ┆ 2022-08-06   ┆ null   │\n",
-       "│             ┆ Foster       ┆        ┆      ┆   ┆            ┆            ┆ 00:08:05     ┆        │\n",
-       "│ 5           ┆ Kevin        ┆ female ┆ 28   ┆ … ┆ 1932-02-09 ┆ 11:39:22   ┆ null         ┆ null   │\n",
-       "│             ┆ Mitchell     ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│ 1           ┆ Kevin        ┆ male   ┆ 53   ┆ … ┆ 1916-12-07 ┆ 11:34:40   ┆ 2022-07-25   ┆ null   │\n",
+       "│             ┆ Martinez     ┆        ┆      ┆   ┆            ┆            ┆ 01:03:01     ┆        │\n",
+       "│ 2           ┆ Julia Gray   ┆ male   ┆ 49   ┆ … ┆ 1939-12-30 ┆ 12:21:49   ┆ null         ┆ null   │\n",
+       "│ 3           ┆ James Rogers ┆ male   ┆ null ┆ … ┆ 1936-11-04 ┆ 13:59:05   ┆ 2022-07-31   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 22:42:29     ┆        │\n",
+       "│ 4           ┆ Jennifer     ┆ female ┆ 30   ┆ … ┆ 1905-11-11 ┆ 16:15:25   ┆ 2022-08-10   ┆ null   │\n",
+       "│             ┆ Johnson MD   ┆        ┆      ┆   ┆            ┆            ┆ 16:44:09     ┆        │\n",
+       "│ 5           ┆ Aaron        ┆ male   ┆ 28   ┆ … ┆ 1920-01-29 ┆ 10:44:21   ┆ 2022-08-10   ┆ null   │\n",
+       "│             ┆ Herrera      ┆        ┆      ┆   ┆            ┆            ┆ 03:17:41     ┆        │\n",
        "└─────────────┴──────────────┴────────┴──────┴───┴────────────┴────────────┴──────────────┴────────┘"
       ]
      },
@@ -848,8 +848,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.34it/s]\n",
-      " PassengerId: 100%|██████████████████████████████████████| 13/13 [00:00<00:00, 870.01variables/s]\n"
+      "100%|██████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.54it/s]\n",
+      " PassengerId: 100%|████████████████████████████████████████| 13/13 [00:00<00:00, 868.10variables/s]\n"
      ]
     },
     {
@@ -862,7 +862,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Ryan Phillips&quot;</td><td>&quot;male&quot;</td><td>21</td><td>0</td><td>&quot;1454&quot;</td><td>0.68373</td><td>null</td><td>&quot;S&quot;</td><td>1930-12-21</td><td>11:12:07</td><td>2022-08-02 03:30:09</td><td>null</td></tr><tr><td>2</td><td>&quot;Jason Benjamin&quot;</td><td>&quot;female&quot;</td><td>32</td><td>0</td><td>&quot;06586&quot;</td><td>0.565665</td><td>null</td><td>&quot;S&quot;</td><td>1918-11-14</td><td>13:41:34</td><td>2022-08-09 12:31:02</td><td>null</td></tr><tr><td>3</td><td>&quot;Laura Elliott&quot;</td><td>&quot;male&quot;</td><td>38</td><td>0</td><td>&quot;7393&quot;</td><td>1.026302</td><td>null</td><td>&quot;S&quot;</td><td>1909-02-12</td><td>18:29:50</td><td>2022-07-25 08:35:54</td><td>null</td></tr><tr><td>4</td><td>&quot;Stephanie Wheeler&quot;</td><td>&quot;male&quot;</td><td>null</td><td>0</td><td>&quot;587626&quot;</td><td>3.450129</td><td>null</td><td>&quot;C&quot;</td><td>1912-04-29</td><td>15:21:34</td><td>null</td><td>null</td></tr><tr><td>5</td><td>&quot;Kara Mercado&quot;</td><td>&quot;male&quot;</td><td>21</td><td>0</td><td>&quot;17892&quot;</td><td>0.655893</td><td>&quot;F0 2B80 B68&quot;</td><td>&quot;C&quot;</td><td>1917-08-19</td><td>15:28:28</td><td>2022-07-15 16:16:50</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (5, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Timothy Valdez&quot;</td><td>&quot;male&quot;</td><td>37</td><td>0</td><td>&quot;90698&quot;</td><td>2.365298</td><td>null</td><td>&quot;C&quot;</td><td>1934-05-12</td><td>15:40:37</td><td>null</td><td>null</td></tr><tr><td>2</td><td>&quot;Robert Rollins&quot;</td><td>&quot;male&quot;</td><td>22</td><td>0</td><td>&quot;QXL.A. 37688&quot;</td><td>0.182746</td><td>null</td><td>&quot;S&quot;</td><td>1912-06-27</td><td>15:06:09</td><td>2022-07-19 01:04:20</td><td>null</td></tr><tr><td>3</td><td>&quot;Matthew Kline&quot;</td><td>&quot;male&quot;</td><td>36</td><td>0</td><td>&quot;09066&quot;</td><td>3.291684</td><td>&quot;G65&quot;</td><td>&quot;C&quot;</td><td>1934-06-18</td><td>11:42:05</td><td>2022-08-11 18:20:07</td><td>null</td></tr><tr><td>4</td><td>&quot;Andrew Lane&quot;</td><td>&quot;female&quot;</td><td>37</td><td>0</td><td>&quot;22371&quot;</td><td>1.371681</td><td>null</td><td>&quot;Q&quot;</td><td>1938-03-13</td><td>16:47:40</td><td>2022-08-05 20:32:48</td><td>null</td></tr><tr><td>5</td><td>&quot;Tracey Williams&quot;</td><td>&quot;female&quot;</td><td>null</td><td>0</td><td>&quot;954224&quot;</td><td>0.52291</td><td>null</td><td>&quot;S&quot;</td><td>1930-12-28</td><td>11:07:33</td><td>2022-07-16 10:43:09</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (5, 13)\n",
@@ -872,16 +872,16 @@
        "│ i64         ┆ str          ┆ cat    ┆ i64  ┆   ┆ date       ┆ time       ┆ ---          ┆ str    │\n",
        "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ datetime[μs] ┆        │\n",
        "╞═════════════╪══════════════╪════════╪══════╪═══╪════════════╪════════════╪══════════════╪════════╡\n",
-       "│ 1           ┆ Ryan         ┆ male   ┆ 21   ┆ … ┆ 1930-12-21 ┆ 11:12:07   ┆ 2022-08-02   ┆ null   │\n",
-       "│             ┆ Phillips     ┆        ┆      ┆   ┆            ┆            ┆ 03:30:09     ┆        │\n",
-       "│ 2           ┆ Jason        ┆ female ┆ 32   ┆ … ┆ 1918-11-14 ┆ 13:41:34   ┆ 2022-08-09   ┆ null   │\n",
-       "│             ┆ Benjamin     ┆        ┆      ┆   ┆            ┆            ┆ 12:31:02     ┆        │\n",
-       "│ 3           ┆ Laura        ┆ male   ┆ 38   ┆ … ┆ 1909-02-12 ┆ 18:29:50   ┆ 2022-07-25   ┆ null   │\n",
-       "│             ┆ Elliott      ┆        ┆      ┆   ┆            ┆            ┆ 08:35:54     ┆        │\n",
-       "│ 4           ┆ Stephanie    ┆ male   ┆ null ┆ … ┆ 1912-04-29 ┆ 15:21:34   ┆ null         ┆ null   │\n",
-       "│             ┆ Wheeler      ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│ 5           ┆ Kara Mercado ┆ male   ┆ 21   ┆ … ┆ 1917-08-19 ┆ 15:28:28   ┆ 2022-07-15   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 16:16:50     ┆        │\n",
+       "│ 1           ┆ Timothy      ┆ male   ┆ 37   ┆ … ┆ 1934-05-12 ┆ 15:40:37   ┆ null         ┆ null   │\n",
+       "│             ┆ Valdez       ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
+       "│ 2           ┆ Robert       ┆ male   ┆ 22   ┆ … ┆ 1912-06-27 ┆ 15:06:09   ┆ 2022-07-19   ┆ null   │\n",
+       "│             ┆ Rollins      ┆        ┆      ┆   ┆            ┆            ┆ 01:04:20     ┆        │\n",
+       "│ 3           ┆ Matthew      ┆ male   ┆ 36   ┆ … ┆ 1934-06-18 ┆ 11:42:05   ┆ 2022-08-11   ┆ null   │\n",
+       "│             ┆ Kline        ┆        ┆      ┆   ┆            ┆            ┆ 18:20:07     ┆        │\n",
+       "│ 4           ┆ Andrew Lane  ┆ female ┆ 37   ┆ … ┆ 1938-03-13 ┆ 16:47:40   ┆ 2022-08-05   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 20:32:48     ┆        │\n",
+       "│ 5           ┆ Tracey       ┆ female ┆ null ┆ … ┆ 1930-12-28 ┆ 11:07:33   ┆ 2022-07-16   ┆ null   │\n",
+       "│             ┆ Williams     ┆        ┆      ┆   ┆            ┆            ┆ 10:43:09     ┆        │\n",
        "└─────────────┴──────────────┴────────┴──────┴───┴────────────┴────────────┴──────────────┴────────┘"
       ]
      },
@@ -919,8 +919,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.83it/s]\n",
-      " PassengerId: 100%|██████████████████████████████████████| 13/13 [00:00<00:00, 714.04variables/s]\n"
+      "100%|██████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.63it/s]\n",
+      " PassengerId: 100%|████████████████████████████████████████| 13/13 [00:00<00:00, 654.03variables/s]\n"
      ]
     },
     {
@@ -933,7 +933,7 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (10, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Ann Little&quot;</td><td>&quot;male&quot;</td><td>27</td><td>0</td><td>&quot;3416&quot;</td><td>1.317871</td><td>&quot;B 9&quot;</td><td>&quot;S&quot;</td><td>1915-10-30</td><td>11:58:10</td><td>2022-07-27 23:45:07</td><td>null</td></tr><tr><td>2</td><td>&quot;Samantha Wilson&quot;</td><td>&quot;male&quot;</td><td>22</td><td>0</td><td>&quot;6435&quot;</td><td>7.122942</td><td>null</td><td>&quot;S&quot;</td><td>1910-12-26</td><td>null</td><td>2022-08-05 10:59:36</td><td>null</td></tr><tr><td>3</td><td>&quot;Keith Fletcher Jr.&quot;</td><td>&quot;female&quot;</td><td>25</td><td>0</td><td>&quot;962432&quot;</td><td>5.582787</td><td>null</td><td>&quot;S&quot;</td><td>1915-09-23</td><td>11:12:35</td><td>2022-07-27 15:34:24</td><td>null</td></tr><tr><td>4</td><td>&quot;Janice Miller&quot;</td><td>&quot;female&quot;</td><td>null</td><td>0</td><td>&quot;408650&quot;</td><td>0.670852</td><td>null</td><td>&quot;S&quot;</td><td>null</td><td>11:01:44</td><td>2022-07-26 21:55:45</td><td>null</td></tr><tr><td>5</td><td>&quot;Mr. Jeremiah Blankenship&quot;</td><td>&quot;male&quot;</td><td>37</td><td>1</td><td>&quot;627839&quot;</td><td>0.909058</td><td>&quot;C94&quot;</td><td>&quot;S&quot;</td><td>1929-11-26</td><td>11:54:49</td><td>2022-07-15 17:20:29</td><td>null</td></tr><tr><td>6</td><td>&quot;Suzanne Anderson&quot;</td><td>&quot;male&quot;</td><td>34</td><td>1</td><td>&quot;0269&quot;</td><td>4.026651</td><td>null</td><td>&quot;S&quot;</td><td>1939-05-02</td><td>16:40:04</td><td>2022-08-03 18:42:30</td><td>null</td></tr><tr><td>7</td><td>&quot;Dana Stout&quot;</td><td>&quot;female&quot;</td><td>20</td><td>0</td><td>&quot;79134&quot;</td><td>0.112219</td><td>null</td><td>&quot;S&quot;</td><td>1929-09-07</td><td>15:15:44</td><td>2022-08-10 11:00:10</td><td>null</td></tr><tr><td>8</td><td>&quot;Shannon Sanford&quot;</td><td>&quot;female&quot;</td><td>null</td><td>0</td><td>&quot;0793&quot;</td><td>1.471682</td><td>null</td><td>&quot;S&quot;</td><td>1938-04-03</td><td>15:15:09</td><td>null</td><td>null</td></tr><tr><td>9</td><td>&quot;Jesse Reed&quot;</td><td>&quot;male&quot;</td><td>36</td><td>1</td><td>&quot;975658&quot;</td><td>0.270754</td><td>null</td><td>&quot;Q&quot;</td><td>1914-09-24</td><td>14:38:50</td><td>2022-08-07 09:10:43</td><td>null</td></tr><tr><td>10</td><td>&quot;Danielle Hensley DDS&quot;</td><td>&quot;female&quot;</td><td>37</td><td>0</td><td>&quot;569282&quot;</td><td>0.397488</td><td>null</td><td>&quot;S&quot;</td><td>1906-05-30</td><td>11:49:36</td><td>2022-08-08 15:43:33</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (10, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>i64</td><td>str</td><td>cat</td><td>i64</td><td>i64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>date</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>1</td><td>&quot;Diane Black&quot;</td><td>&quot;male&quot;</td><td>23</td><td>0</td><td>&quot;318265&quot;</td><td>0.252095</td><td>&quot;C &quot;</td><td>&quot;C&quot;</td><td>1928-03-31</td><td>11:07:45</td><td>2022-07-21 10:21:24</td><td>null</td></tr><tr><td>2</td><td>&quot;Kevin Caldwell&quot;</td><td>&quot;male&quot;</td><td>null</td><td>1</td><td>&quot;88086&quot;</td><td>0.661904</td><td>null</td><td>&quot;S&quot;</td><td>1905-06-20</td><td>18:08:45</td><td>2022-07-17 13:38:36</td><td>null</td></tr><tr><td>3</td><td>&quot;Whitney Johnson PhD&quot;</td><td>&quot;male&quot;</td><td>23</td><td>0</td><td>&quot;86558&quot;</td><td>1.108456</td><td>null</td><td>&quot;S&quot;</td><td>1907-08-02</td><td>14:52:11</td><td>2022-08-13 04:58:18</td><td>null</td></tr><tr><td>4</td><td>&quot;Leslie Smith&quot;</td><td>&quot;male&quot;</td><td>38</td><td>1</td><td>&quot;8906&quot;</td><td>0.519185</td><td>null</td><td>&quot;Q&quot;</td><td>null</td><td>null</td><td>2022-07-22 08:05:58</td><td>null</td></tr><tr><td>5</td><td>&quot;Caroline Johnson&quot;</td><td>&quot;female&quot;</td><td>29</td><td>0</td><td>&quot;0175&quot;</td><td>1.806149</td><td>null</td><td>&quot;S&quot;</td><td>1929-07-13</td><td>11:18:20</td><td>2022-07-22 03:42:33</td><td>null</td></tr><tr><td>6</td><td>&quot;Amy Miranda&quot;</td><td>&quot;male&quot;</td><td>null</td><td>0</td><td>&quot;6517&quot;</td><td>0.597362</td><td>null</td><td>&quot;S&quot;</td><td>1929-10-11</td><td>10:45:39</td><td>2022-08-04 09:31:21</td><td>null</td></tr><tr><td>7</td><td>&quot;Stuart Nelson MD&quot;</td><td>&quot;male&quot;</td><td>36</td><td>0</td><td>&quot;70386&quot;</td><td>1.520651</td><td>null</td><td>&quot;S&quot;</td><td>1929-09-09</td><td>15:15:02</td><td>2022-07-27 20:31:34</td><td>null</td></tr><tr><td>8</td><td>&quot;David French&quot;</td><td>&quot;male&quot;</td><td>38</td><td>0</td><td>&quot;18289&quot;</td><td>0.778164</td><td>null</td><td>&quot;C&quot;</td><td>1939-04-30</td><td>15:37:31</td><td>2022-07-30 10:54:49</td><td>null</td></tr><tr><td>9</td><td>&quot;Randy White&quot;</td><td>&quot;female&quot;</td><td>33</td><td>0</td><td>&quot;33236&quot;</td><td>0.305995</td><td>&quot;A94&quot;</td><td>&quot;C&quot;</td><td>1914-09-05</td><td>13:13:20</td><td>2022-08-08 17:03:49</td><td>null</td></tr><tr><td>10</td><td>&quot;Shane Vincent&quot;</td><td>&quot;male&quot;</td><td>25</td><td>0</td><td>&quot;55263&quot;</td><td>2.852744</td><td>null</td><td>&quot;S&quot;</td><td>1934-10-22</td><td>12:01:04</td><td>null</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (10, 13)\n",
@@ -943,26 +943,26 @@
        "│ i64         ┆ str          ┆ cat    ┆ i64  ┆   ┆ date       ┆ time       ┆ ---          ┆ str    │\n",
        "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ datetime[μs] ┆        │\n",
        "╞═════════════╪══════════════╪════════╪══════╪═══╪════════════╪════════════╪══════════════╪════════╡\n",
-       "│ 1           ┆ Ann Little   ┆ male   ┆ 27   ┆ … ┆ 1915-10-30 ┆ 11:58:10   ┆ 2022-07-27   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 23:45:07     ┆        │\n",
-       "│ 2           ┆ Samantha     ┆ male   ┆ 22   ┆ … ┆ 1910-12-26 ┆ null       ┆ 2022-08-05   ┆ null   │\n",
-       "│             ┆ Wilson       ┆        ┆      ┆   ┆            ┆            ┆ 10:59:36     ┆        │\n",
-       "│ 3           ┆ Keith        ┆ female ┆ 25   ┆ … ┆ 1915-09-23 ┆ 11:12:35   ┆ 2022-07-27   ┆ null   │\n",
-       "│             ┆ Fletcher Jr. ┆        ┆      ┆   ┆            ┆            ┆ 15:34:24     ┆        │\n",
-       "│ 4           ┆ Janice       ┆ female ┆ null ┆ … ┆ null       ┆ 11:01:44   ┆ 2022-07-26   ┆ null   │\n",
-       "│             ┆ Miller       ┆        ┆      ┆   ┆            ┆            ┆ 21:55:45     ┆        │\n",
-       "│ 5           ┆ Mr. Jeremiah ┆ male   ┆ 37   ┆ … ┆ 1929-11-26 ┆ 11:54:49   ┆ 2022-07-15   ┆ null   │\n",
-       "│             ┆ Blankenship  ┆        ┆      ┆   ┆            ┆            ┆ 17:20:29     ┆        │\n",
-       "│ 6           ┆ Suzanne      ┆ male   ┆ 34   ┆ … ┆ 1939-05-02 ┆ 16:40:04   ┆ 2022-08-03   ┆ null   │\n",
-       "│             ┆ Anderson     ┆        ┆      ┆   ┆            ┆            ┆ 18:42:30     ┆        │\n",
-       "│ 7           ┆ Dana Stout   ┆ female ┆ 20   ┆ … ┆ 1929-09-07 ┆ 15:15:44   ┆ 2022-08-10   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 11:00:10     ┆        │\n",
-       "│ 8           ┆ Shannon      ┆ female ┆ null ┆ … ┆ 1938-04-03 ┆ 15:15:09   ┆ null         ┆ null   │\n",
-       "│             ┆ Sanford      ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
-       "│ 9           ┆ Jesse Reed   ┆ male   ┆ 36   ┆ … ┆ 1914-09-24 ┆ 14:38:50   ┆ 2022-08-07   ┆ null   │\n",
-       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 09:10:43     ┆        │\n",
-       "│ 10          ┆ Danielle     ┆ female ┆ 37   ┆ … ┆ 1906-05-30 ┆ 11:49:36   ┆ 2022-08-08   ┆ null   │\n",
-       "│             ┆ Hensley DDS  ┆        ┆      ┆   ┆            ┆            ┆ 15:43:33     ┆        │\n",
+       "│ 1           ┆ Diane Black  ┆ male   ┆ 23   ┆ … ┆ 1928-03-31 ┆ 11:07:45   ┆ 2022-07-21   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 10:21:24     ┆        │\n",
+       "│ 2           ┆ Kevin        ┆ male   ┆ null ┆ … ┆ 1905-06-20 ┆ 18:08:45   ┆ 2022-07-17   ┆ null   │\n",
+       "│             ┆ Caldwell     ┆        ┆      ┆   ┆            ┆            ┆ 13:38:36     ┆        │\n",
+       "│ 3           ┆ Whitney      ┆ male   ┆ 23   ┆ … ┆ 1907-08-02 ┆ 14:52:11   ┆ 2022-08-13   ┆ null   │\n",
+       "│             ┆ Johnson PhD  ┆        ┆      ┆   ┆            ┆            ┆ 04:58:18     ┆        │\n",
+       "│ 4           ┆ Leslie Smith ┆ male   ┆ 38   ┆ … ┆ null       ┆ null       ┆ 2022-07-22   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 08:05:58     ┆        │\n",
+       "│ 5           ┆ Caroline     ┆ female ┆ 29   ┆ … ┆ 1929-07-13 ┆ 11:18:20   ┆ 2022-07-22   ┆ null   │\n",
+       "│             ┆ Johnson      ┆        ┆      ┆   ┆            ┆            ┆ 03:42:33     ┆        │\n",
+       "│ 6           ┆ Amy Miranda  ┆ male   ┆ null ┆ … ┆ 1929-10-11 ┆ 10:45:39   ┆ 2022-08-04   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 09:31:21     ┆        │\n",
+       "│ 7           ┆ Stuart       ┆ male   ┆ 36   ┆ … ┆ 1929-09-09 ┆ 15:15:02   ┆ 2022-07-27   ┆ null   │\n",
+       "│             ┆ Nelson MD    ┆        ┆      ┆   ┆            ┆            ┆ 20:31:34     ┆        │\n",
+       "│ 8           ┆ David French ┆ male   ┆ 38   ┆ … ┆ 1939-04-30 ┆ 15:37:31   ┆ 2022-07-30   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 10:54:49     ┆        │\n",
+       "│ 9           ┆ Randy White  ┆ female ┆ 33   ┆ … ┆ 1914-09-05 ┆ 13:13:20   ┆ 2022-08-08   ┆ null   │\n",
+       "│             ┆              ┆        ┆      ┆   ┆            ┆            ┆ 17:03:49     ┆        │\n",
+       "│ 10          ┆ Shane        ┆ male   ┆ 25   ┆ … ┆ 1934-10-22 ┆ 12:01:04   ┆ null         ┆ null   │\n",
+       "│             ┆ Vincent      ┆        ┆      ┆   ┆            ┆            ┆              ┆        │\n",
        "└─────────────┴──────────────┴────────┴──────┴───┴────────────┴────────────┴──────────────┴────────┘"
       ]
      },
@@ -1050,7 +1050,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " PassengerId: 100%|███████████████████████████████████████| 13/13 [00:00<00:00, 18.05variables/s]\n"
+      " PassengerId: 100%|█████████████████████████████████████████| 13/13 [00:00<00:00, 18.34variables/s]\n"
      ]
     },
     {
@@ -1063,20 +1063,20 @@
        "  white-space: pre-wrap;\n",
        "}\n",
        "</style>\n",
-       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>f64</td><td>str</td><td>cat</td><td>f64</td><td>f64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>datetime[μs]</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>446.0</td><td>null</td><td>null</td><td>29.37535</td><td>0.078563</td><td>null</td><td>1.669456</td><td>null</td><td>null</td><td>1922-01-03 20:18:35.867159</td><td>14:40:20.522167487</td><td>2022-07-30 21:29:40.495619</td><td>null</td></tr></tbody></table></div>"
+       "<small>shape: (1, 13)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>PassengerId</th><th>Name</th><th>Sex</th><th>Age</th><th>Parch</th><th>Ticket</th><th>Fare</th><th>Cabin</th><th>Embarked</th><th>Birthday</th><th>Board time</th><th>Married since</th><th>all_NA</th></tr><tr><td>f64</td><td>str</td><td>cat</td><td>f64</td><td>f64</td><td>str</td><td>f64</td><td>str</td><td>cat</td><td>datetime[μs]</td><td>time</td><td>datetime[μs]</td><td>str</td></tr></thead><tbody><tr><td>446.0</td><td>null</td><td>null</td><td>29.242297</td><td>0.069585</td><td>null</td><td>1.631075</td><td>null</td><td>null</td><td>1922-05-08 20:25:40.959410</td><td>14:46:23.392857142</td><td>2022-07-31 03:38:07.117647</td><td>null</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "shape: (1, 13)\n",
-       "┌─────────────┬──────┬──────┬──────────┬───┬───────────────┬───────────────┬──────────────┬────────┐\n",
-       "│ PassengerId ┆ Name ┆ Sex  ┆ Age      ┆ … ┆ Birthday      ┆ Board time    ┆ Married      ┆ all_NA │\n",
-       "│ ---         ┆ ---  ┆ ---  ┆ ---      ┆   ┆ ---           ┆ ---           ┆ since        ┆ ---    │\n",
-       "│ f64         ┆ str  ┆ cat  ┆ f64      ┆   ┆ datetime[μs]  ┆ time          ┆ ---          ┆ str    │\n",
-       "│             ┆      ┆      ┆          ┆   ┆               ┆               ┆ datetime[μs] ┆        │\n",
-       "╞═════════════╪══════╪══════╪══════════╪═══╪═══════════════╪═══════════════╪══════════════╪════════╡\n",
-       "│ 446.0       ┆ null ┆ null ┆ 29.37535 ┆ … ┆ 1922-01-03    ┆ 14:40:20.5221 ┆ 2022-07-30   ┆ null   │\n",
-       "│             ┆      ┆      ┆          ┆   ┆ 20:18:35.8671 ┆ 67487         ┆ 21:29:40.495 ┆        │\n",
-       "│             ┆      ┆      ┆          ┆   ┆ 59            ┆               ┆ 619          ┆        │\n",
-       "└─────────────┴──────┴──────┴──────────┴───┴───────────────┴───────────────┴──────────────┴────────┘"
+       "┌─────────────┬──────┬──────┬───────────┬───┬───────────────┬──────────────┬──────────────┬────────┐\n",
+       "│ PassengerId ┆ Name ┆ Sex  ┆ Age       ┆ … ┆ Birthday      ┆ Board time   ┆ Married      ┆ all_NA │\n",
+       "│ ---         ┆ ---  ┆ ---  ┆ ---       ┆   ┆ ---           ┆ ---          ┆ since        ┆ ---    │\n",
+       "│ f64         ┆ str  ┆ cat  ┆ f64       ┆   ┆ datetime[μs]  ┆ time         ┆ ---          ┆ str    │\n",
+       "│             ┆      ┆      ┆           ┆   ┆               ┆              ┆ datetime[μs] ┆        │\n",
+       "╞═════════════╪══════╪══════╪═══════════╪═══╪═══════════════╪══════════════╪══════════════╪════════╡\n",
+       "│ 446.0       ┆ null ┆ null ┆ 29.242297 ┆ … ┆ 1922-05-08    ┆ 14:46:23.392 ┆ 2022-07-31   ┆ null   │\n",
+       "│             ┆      ┆      ┆           ┆   ┆ 20:25:40.9594 ┆ 857142       ┆ 03:38:07.117 ┆        │\n",
+       "│             ┆      ┆      ┆           ┆   ┆ 10            ┆              ┆ 647          ┆        │\n",
+       "└─────────────┴──────┴──────┴───────────┴───┴───────────────┴──────────────┴──────────────┴────────┘"
       ]
      },
      "execution_count": 17,
@@ -1144,7 +1144,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " PassengerId: 100%|███████████████████████████████████████| 13/13 [00:00<00:00, 18.50variables/s]\n"
+      " PassengerId: 100%|█████████████████████████████████████████| 13/13 [00:00<00:00, 18.44variables/s]\n"
      ]
     },
     {
@@ -1222,7 +1222,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.34it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████| 13/13 [00:01<00:00,  7.54it/s]\n"
      ]
     }
    ],
@@ -1387,17 +1387,58 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a38ac75-9ab9-41c5-b445-475cce519a87",
+   "metadata": {},
+   "source": [
+    "## Step 8: Look at the fit log (but don't publish it)\n",
+    "\n",
+    "Before publishing your synthetic dataset, it is important to check the fitting process that created the metaframe and synthatic dataset. This will give hints on whether your fitting process produces safe results or whether there are still some things that need adjustment. This is particularly useful when you are using a privacy plugin such as [disclosure control](https://github.com/sodascience/metasyn-disclosure-control).\n",
+    "\n",
+    "While this fit log can help understand the level of privacy, this information itself is not generally safe to publish, even if the resulting synthetic data is. **Do not publish the fit log.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "7fe67338-99d4-4dcf-88e8-954a9969c8ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- created_by: metasyn\n",
+      "- method: Fitting regex using method 'auto' and count threshold None.\n",
+      "- recipe: Fit multiple candidate distributions, unique and non-unique (for warnings): RegexFitter, StringConstantFitter, MultinoulliFitter, FakerFitter, FreeTextFitter, NAFitter, UniqueRegexFitter, UniqueFakerFitter\n",
+      "- fitter: Fitter RegexFitter version 2.0 from plugin builtin-2.1.0. The privacy was done using the basic privacy features of metasyn.\n",
+      "- bic: 0\n",
+      "- privacy: The privacy was done using the basic privacy features of metasyn.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print the fit log for the column \"Cabin\"\n",
+    "print(builder.fit_log[\"Cabin\"])\n",
+    "\n",
+    "# You can also save the fit log to a csv or markdown file\n",
+    "builder.fit_log.save_md(\"fit_log.md\")\n",
+    "builder.fit_log.save_csv(\"fit_log.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "729f3ca5",
    "metadata": {},
    "source": [
-    "## Step 8: Write your synthetic data to a file.\n",
+    "## Step 9: Write your synthetic data to a file.\n",
     "\n",
     "Most likely you will save the synthetic file back to a file. You can in the case of a csv file use `polars.write_csv()`. Even better is to reuse the file format that has been created when reading in the file. This ensures that if for example the file was read in with a certain encoding, the output file will have the same encoding. To write the file using the file format created in Step 1, use `metasyn.write_csv`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "f8c55c4f",
    "metadata": {},
    "outputs": [
@@ -1405,7 +1446,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      " PassengerId: 100%|██████████████████████████████████████| 13/13 [00:00<00:00, 135.97variables/s]\n"
+      " PassengerId: 100%|████████████████████████████████████████| 13/13 [00:00<00:00, 133.07variables/s]\n"
      ]
     }
    ],
@@ -1431,14 +1472,6 @@
     "If you have any questions, feel free to [reach out](https://metasyn.readthedocs.io/en/latest/about.html#contact-us).\n",
     "\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "96390bc2-e7fb-4fb5-aed7-aac155ded6bb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/gmf_files/example_gmf_titanic.json
+++ b/examples/gmf_files/example_gmf_titanic.json
@@ -1,11 +1,11 @@
 {
-    "gmf_version": "2.0",
+    "gmf_version": "2.1",
     "provenance": {
         "created by": {
             "name": "metasyn",
             "version": "2.1.0"
         },
-        "creation time": "2026-06-24T14:29:46.844534"
+        "creation time": "2026-08-12T15:15:46.675361"
     },
     "tables": [
         {

--- a/metasyn/builder.py
+++ b/metasyn/builder.py
@@ -500,7 +500,7 @@ class FitterRecipe(BaseRecipe):
     series: pl.Series
     fitter: BaseFitter
 
-    def fit(self, fit_log: FitLog):
+    def fit(self, fit_log: VarLog):
         fit_log.add(recipe="Single fitter.")
         fit_log.add(created_by="metasyn")
         fit_log.add(fitter=self.fitter)

--- a/metasyn/builder.py
+++ b/metasyn/builder.py
@@ -13,7 +13,7 @@ import numpy as np
 import polars as pl
 from tqdm import tqdm
 
-from metasyn.distribution.base import BaseFitter, DistributionLike
+from metasyn.distribution.base import BaseFitter, DistributionLike, VarLog
 from metasyn.file import BaseFileInterface
 from metasyn.metaframe import MetaFrame
 from metasyn.privacy import BasePrivacy, BasicPrivacy
@@ -25,6 +25,37 @@ try:
     import tomllib
 except ImportError:
     import tomli as tomllib  # type: ignore  # noqa
+
+
+class FitLog():
+    def __init__(self):
+        self.log = {}
+
+    def write_csv(self, fp):
+        pl.write_csv(pl.DataFrame(self.log), fp)
+
+    def __getitem__(self, key):
+        return self.log[key]
+
+    def __setitem__(self, key, val):
+        self.log[key] = val
+
+    def add_col(self, name):
+        self.log[name] = VarLog()
+
+    def reset(self):
+        for key in self.log:
+            self.log[key] = VarLog()
+
+    def print(self):
+        pass
+        # print("\n\n".join(str(x) for x in self.log.values()))
+
+    def to_dataframe(self):
+        index = self.log[list(self.log)[0]].attrs
+        all_series = {"Index": index}
+        all_series.update({col: self.log[col].to_series(col) for col in self.log})
+        return pl.DataFrame(all_series)
 
 
 class VarBuilder():
@@ -167,38 +198,7 @@ class VarBuilder():
                 return recipe
         raise TypeError(f"Cannot find recipe for distribution {self.distribution}, wrong type?.")
 
-    def get_creation_method(self, fitter: BaseFitter | str | None) -> dict:
-        """Create a dictionary on how the distribution was created.
-
-        Parameters
-        ----------
-        privacy
-            Privacy object with which the dictionary is being created.
-
-        Returns
-        -------
-            Dictionary containing all the non-default settings for the creation method.
-        """
-        if isinstance(fitter, str):
-            ret_dict: dict[str, Any] = {"created_by": fitter}
-        else:
-            ret_dict = {"created_by": "metasyn"}
-        if isinstance(self.distribution, dict):
-            dist_dict = {var: self.distribution.get(var)
-                         for var in ["name", "unique", "parameters", "version"]
-                         if var in self.distribution}
-            if len(dist_dict) != 0:
-                ret_dict["distribution"] = dist_dict
-        fit_dict = {}
-        if fitter is not None and isinstance(fitter, BaseFitter):
-            fit_dict = fitter.to_dict()
-
-        if len(fit_dict) != 0:
-            ret_dict["fitter"] = fit_dict
-
-        return ret_dict
-
-    def fit(self):
+    def fit(self, fit_log: FitLog | None = None):
         """Fit or create the distribution.
 
         Returns
@@ -211,12 +211,14 @@ class VarBuilder():
             prop_missing = 0.0
         else:
             prop_missing = self.prop_missing
-        dist, fitter = self.recipe.fit()
         if self.var_type is None:
             raise ValueError("Could not detect variable type, please set variable type for "
                              f"'{self.name}'.")
+        if fit_log is None:
+            fit_log = VarLog()
+        dist = self.recipe.fit(fit_log)
         return MetaVar(self.name, self.var_type, dist, self.dtype, self.description,
-                       prop_missing, creation_method=self.get_creation_method(fitter),
+                       prop_missing, creation_method=fit_log.creation_method,
                        hidden=self.hidden)
 
     def _find_fitters(self, unique):
@@ -252,6 +254,7 @@ class MetaFrameBuilder():
         self.plugins = None
         self.name = name
         self.defaults = {}
+        self.fit_log = FitLog()
 
     def __getitem__(self, item: str):
         return self.var_builders[item]
@@ -271,6 +274,7 @@ class MetaFrameBuilder():
         self.file_format = file_format
         for col in df.columns:
             self.var_builders[col] = VarBuilder(df[col], col, self)
+            self.fit_log.add_col(col)
         self.n_rows = len(df) if self.n_rows is None else self.n_rows
 
     def add_column(self, name: str, hidden: bool = False, var_type: str | None = None):
@@ -282,6 +286,7 @@ class MetaFrameBuilder():
             Name of the new column.
         """
         self.var_builders[name] = VarBuilder(None, name, self, hidden=hidden, var_type=var_type)
+        self.fit_log.add_col(name)
         self.columns.append(name)
 
     def add_config(self, config: Path | str | dict) -> "MetaFrameBuilder":
@@ -356,8 +361,9 @@ class MetaFrameBuilder():
             Whether to display a progress bar.
         """
         vars = []
+        self.fit_log.reset()
         for col in tqdm(self.columns, disable=not progress_bar):
-            vars.append(self.var_builders[col].fit())
+            vars.append(self.var_builders[col].fit(self.fit_log[col]))
         return MetaFrame(vars, self.n_rows, self.file_format, self.name)
 
 class ConfigV1XParser():
@@ -412,7 +418,7 @@ class BaseRecipe(ABC):
     """Base class for distribution recipes."""
 
     @abstractmethod
-    def fit(self) -> DistributionLike:
+    def fit(self, fit_log: FitLog) -> DistributionLike:
         """Use the recipe to fit or get the correct distribution."""
         pass
 
@@ -432,8 +438,10 @@ class DistributionRecipe(BaseRecipe):
 
     distribution: DistributionLike
 
-    def fit(self):
-        return self.distribution, "user"
+    def fit(self, fit_log):
+        fit_log.add(created_by="user")
+        fit_log.add(recipe="User defined distribution.")
+        return self.distribution
 
     @classmethod
     def create(cls, var_builder: VarBuilder):
@@ -468,14 +476,16 @@ class FitterRecipe(BaseRecipe):
     series: pl.Series
     fitter: BaseFitter
 
-    def fit(self):
-        return self.fitter.fit(self.series), self.fitter
+    def fit(self, fit_log: FitLog):
+        fit_log.add(recipe="Single fitter.")
+        fit_log.add(created_by="metasyn")
+        fit_log.add(fitter=self.fitter)
+        return self.fitter.fit(self.series, fit_log)
 
     @classmethod
     def create(cls, var_builder: VarBuilder):
         if isinstance(var_builder.fitter, BaseFitter) and var_builder.series is not None:
             return cls(var_builder.series, var_builder.fitter)
-
         return None
 
 
@@ -486,18 +496,20 @@ class FindDistributionRecipe(BaseRecipe):
     series: pl.Series
     fitters: list[BaseFitter]
 
-    def fit(self):
-        if len(self.fitters) == 1:
-            return FitterRecipe(self.series, self.fitters[0]).fit()
-        if len(self.fitters) == 0:
-            raise ValueError()
-
-        return self.fit_with_bic(self.series)[:2]
+    def fit(self, fit_log):
+        fit_log.add(created_by="metasyn")
+        fit_log.add(recipe="Fit multiple distributions: "
+                    f"({', '.join(f.__class__.__name__ for f in self.fitters)}).")
+        dist, fit_dict = self.fit_with_bic(self.series)
+        fit_log.extend(fit_dict)
+        return dist
 
     def fit_with_bic(self, series):
-        distributions = [f.fit(series) for f in self.fitters]
+        fit_logs = [VarLog() for _ in range(len(self.fitters))]
+        distributions = [f.fit(series, f_log) for f, f_log in zip(self.fitters, fit_logs)]
         bic = [d.information_criterion(series) for d in distributions]
-        return distributions[np.argmin(bic)], self.fitters[np.argmin(bic)], np.min(bic)
+        return (distributions[np.argmin(bic)],
+                VarLog().extend(fit_logs[np.argmin(bic)]).add(bic=min(bic)).add(fitter=self.fitters[np.argmin(bic)]))
 
     @classmethod
     def create(cls, var_builder: VarBuilder):
@@ -514,7 +526,7 @@ class FindDistributionRecipe(BaseRecipe):
             if len(fitters) == 1:
                 return FitterRecipe(var_builder.series, fitters[0])
             elif len(fitters) > 1:
-                return cls(var_builder.series, )
+                return cls(var_builder.series, fitters)
         return None
 
 @dataclass
@@ -525,16 +537,18 @@ class UnqFindDistributionRecipe(BaseRecipe):
     fitters: list[BaseFitter]
     unq_fitters: list[BaseFitter]
 
-    def fit(self):
+    def fit(self, fit_log):
+        fit_log.add(created_by="metasyn")
+        fit_log.add(recipe="Fit multiple distributions, unique and non-unique (for warnings): "
+                     + ", ".join([x.__class__.__name__ for x in self.fitters + self.unq_fitters]))
         series = self.series
-        dist, fitter, bic = FindDistributionRecipe(self.series, self.fitters).fit_with_bic(series)
-        if len(self.unq_fitters) == 0:
-            return dist, fitter
-        unq_dist, unq_fitter, unq_bic = FindDistributionRecipe(self.series,
+        dist, non_fit_log = FindDistributionRecipe(self.series, self.fitters).fit_with_bic(series)
+        unq_dist, unq_fit_log = FindDistributionRecipe(self.series,
                                                                self.unq_fitters).fit_with_bic(series)
-        if unq_bic + 16 < bic:
+        if unq_fit_log.bic[-1] + 16 < non_fit_log.bic[-1]:
             if unq_dist.name == "core.unique_key" and unq_dist.consecutive:
-                return unq_dist, unq_fitter
+                fit_log.extend(unq_fit_log)
+                return unq_dist
             warnings.warn(
                 f"\nMetasyn detected that variable '{series.name}' is potentially unique.\n"
                 f"Use var_spec=[VarSpec(\"{series.name}\", unique=True)] to make it unique."
@@ -543,7 +557,8 @@ class UnqFindDistributionRecipe(BaseRecipe):
                 f" for the variable with name '{series.name}'.",
                 UserWarning
             )
-        return dist, fitter
+        fit_log.extend(non_fit_log)
+        return dist
 
     @classmethod
     def create(cls, var_builder: VarBuilder):
@@ -555,4 +570,12 @@ class UnqFindDistributionRecipe(BaseRecipe):
                     and var_builder.series is not None):
             fitters = var_builder._find_fitters(False)
             unq_fitters = var_builder._find_fitters(True)
+            if len(unq_fitters) == 0:
+                if len(fitters) == 1:
+                    return FitterRecipe(var_builder.series, fitters[0])
+                return FindDistributionRecipe(var_builder.series, fitters)
+            if len(fitters) == 0:
+                if len(unq_fitters) == 1:
+                    return FitterRecipe(var_builder.series, unq_fitters[0])
+                return FindDistributionRecipe(var_builder.series, unq_fitters)
             return cls(var_builder.series, fitters, unq_fitters)

--- a/metasyn/builder.py
+++ b/metasyn/builder.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractclassmethod, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 import polars as pl
@@ -28,30 +28,54 @@ except ImportError:
 
 
 class FitLog():
+    """Logbook for the builder fitting process."""
+
     def __init__(self):
         self.log = {}
 
-    def write_csv(self, fp):
+    def write_csv(self, fp: Path | str):
+        """Create a CSV file containing fitting data for each column.
+
+        Parameters
+        ----------
+        fp:
+            File to write to.
+        """
         pl.write_csv(pl.DataFrame(self.log), fp)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> VarLog:
         return self.log[key]
 
-    def __setitem__(self, key, val):
+    def __setitem__(self, key: str, val: VarLog):
         self.log[key] = val
 
-    def add_col(self, name):
+    def add_col(self, name: str):
+        """Create fit log entry for column.
+
+        Parameters
+        ----------
+        name:
+            Name of the column to add.
+        """
         self.log[name] = VarLog()
 
     def reset(self):
+        """Remove all logs, but keep columns."""
         for key in self.log:
             self.log[key] = VarLog()
 
-    def print(self):
-        pass
+    # def print(self):
+        # pass
         # print("\n\n".join(str(x) for x in self.log.values()))
 
-    def to_dataframe(self):
+    def to_dataframe(self) -> pl.DataFrame:
+        """Create dataframe from fit log.
+
+        Returns
+        -------
+        df:
+            Dataframe containing all entries in the log.
+        """
         index = self.log[list(self.log)[0]].attrs
         all_series = {"Index": index}
         all_series.update({col: self.log[col].to_series(col) for col in self.log})
@@ -198,7 +222,7 @@ class VarBuilder():
                 return recipe
         raise TypeError(f"Cannot find recipe for distribution {self.distribution}, wrong type?.")
 
-    def fit(self, fit_log: FitLog | None = None):
+    def fit(self, fit_log: VarLog | None = None):
         """Fit or create the distribution.
 
         Returns
@@ -418,7 +442,7 @@ class BaseRecipe(ABC):
     """Base class for distribution recipes."""
 
     @abstractmethod
-    def fit(self, fit_log: FitLog) -> DistributionLike:
+    def fit(self, fit_log: VarLog) -> DistributionLike:
         """Use the recipe to fit or get the correct distribution."""
         pass
 

--- a/metasyn/builder.py
+++ b/metasyn/builder.py
@@ -34,7 +34,7 @@ class FitLog():
     def __init__(self):
         self.log = {}
 
-    def write_csv(self, fp: Path | str):
+    def save_csv(self, fp: Path | str):
         """Create a CSV file containing fitting data for each column.
 
         Parameters
@@ -44,7 +44,7 @@ class FitLog():
         """
         self.to_dataframe().write_csv(fp)
 
-    def write_md(self, fp: Path | str):
+    def save_md(self, fp: Path | str):
         md_str = "# Fit log\n"
         for key in self.log:
             md_str += self.log[key].to_md(key) + "\n"
@@ -75,6 +75,19 @@ class FitLog():
     # def print(self):
         # pass
         # print("\n\n".join(str(x) for x in self.log.values()))
+
+    def __str__(self) -> str:
+        var_str_list = ["Fit notes:"]
+        for var_name, var_log in self.log.items():
+            var_str = str(var_log)
+            var_str.replace("\n", "  \n")
+            var_str.replace("\n  \n", "\n\n")
+            if len(var_str) == 0:
+                continue
+            var_str_list.append(f"Notes on column {var_name}:\n\n{var_str}")
+
+        return "\n\n".join(var_str_list)
+            # fit_str += var_str
 
     def to_dataframe(self) -> pl.DataFrame:
         """Create dataframe from fit log.

--- a/metasyn/builder.py
+++ b/metasyn/builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from abc import ABC, abstractclassmethod, abstractmethod
+from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,7 +42,14 @@ class FitLog():
         fp:
             File to write to.
         """
-        pl.write_csv(pl.DataFrame(self.log), fp)
+        self.to_dataframe().write_csv(fp)
+
+    def write_md(self, fp: Path | str):
+        md_str = "# Fit log\n"
+        for key in self.log:
+            md_str += self.log[key].to_md(key) + "\n"
+        with open(fp, "w", encoding="utf-8") as handle:
+            handle.write(md_str)
 
     def __getitem__(self, key: str) -> VarLog:
         return self.log[key]
@@ -76,10 +84,13 @@ class FitLog():
         df:
             Dataframe containing all entries in the log.
         """
-        index = self.log[list(self.log)[0]].attrs
-        all_series = {"Index": index}
-        all_series.update({col: self.log[col].to_series(col) for col in self.log})
-        return pl.DataFrame(all_series)
+        data_dict = defaultdict(list)
+        data_dict["column"] = list(self.log)
+
+        for var_name, var_log in self.log.items():
+            for key, val in var_log.to_dict().items():
+                data_dict[key].append(val)
+        return pl.DataFrame(data_dict)
 
 
 class VarBuilder():
@@ -522,7 +533,7 @@ class FindDistributionRecipe(BaseRecipe):
 
     def fit(self, fit_log):
         fit_log.add(created_by="metasyn")
-        fit_log.add(recipe="Fit multiple distributions: "
+        fit_log.add(recipe="Fit multiple candidate distributions: "
                     f"({', '.join(f.__class__.__name__ for f in self.fitters)}).")
         dist, fit_dict = self.fit_with_bic(self.series)
         fit_log.extend(fit_dict)
@@ -563,7 +574,8 @@ class UnqFindDistributionRecipe(BaseRecipe):
 
     def fit(self, fit_log):
         fit_log.add(created_by="metasyn")
-        fit_log.add(recipe="Fit multiple distributions, unique and non-unique (for warnings): "
+        fit_log.add(recipe="Fit multiple candidate distributions, unique and non-unique "
+                    "(for warnings): "
                      + ", ".join([x.__class__.__name__ for x in self.fitters + self.unq_fitters]))
         series = self.series
         dist, non_fit_log = FindDistributionRecipe(self.series, self.fitters).fit_with_bic(series)

--- a/metasyn/distribution/__init__.py
+++ b/metasyn/distribution/__init__.py
@@ -27,7 +27,6 @@ from metasyn.distribution.base import (
     PlusOperator,
     PowerOperator,
     SubOperator,
-    IsNull,
 )
 from metasyn.distribution.categorical import MultinoulliDistribution, MultinoulliFitter
 from metasyn.distribution.constant import (

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -43,6 +43,8 @@ def convert_to_series(values: Union[npt.NDArray, pl.Series]) -> pl.Series:
     return series
 
 class VarLog():
+    """Log book for fitting single variables."""
+
     attrs = ["created_by", "method", "recipe", "fitter", "bic", "privacy"]
 
     def __init__(self):
@@ -53,7 +55,24 @@ class VarLog():
         self.bic = []
         self.privacy = []
 
-    def add(self, **kwargs):
+    def add(self, **kwargs) -> VarLog:
+        """Add a new entry to the log book.
+
+        Parameters
+        ----------
+        kwargs:
+            Entries to be added to the log book. Choose from
+            ["created_by", "method", "recipe", "fitter", "bic", "privacy"] for the keywords.
+
+        Examples
+        --------
+        >>> vlog = VarLog()
+        >>> vlog.add(method="This is a method message", bic=2.34)
+
+        Returns
+        -------
+            Itself.
+        """
         for key, val in kwargs.items():
             getattr(self, key).append(val)
             if isinstance(val, BaseFitter):
@@ -61,12 +80,29 @@ class VarLog():
         return self
 
     def extend(self, other):
+        """Extend the varlog with another one.
+
+        Parameters
+        ----------
+        other:
+            The other VarLog object to extend with.
+
+        Returns
+        -------
+            Itself.
+        """
         for attr in self.attrs:
             getattr(self, attr).extend(getattr(other, attr, []))
         return self
 
     @property
     def creation_method(self) -> dict:
+        """Get a dictionary with information on how the distribution was created.
+
+        Returns
+        -------
+            A dictionary with the keys "created_by" and "fitter".
+        """
         if len(self.fitter) == 0:
             fitter = None
         elif len(self.fitter) == 1:
@@ -78,13 +114,26 @@ class VarLog():
             "fitter": fitter,
         }
 
-    def to_series(self, name):
+    def to_series(self, name: str | None = None):
+        """Create a series from a var_log.
+
+        Parameters
+        ----------
+        name:
+
+
+        Returns
+        -------
+        series:
+            Polars series with the different attributes of the var log
+        """
         descriptions = []
         for attr in self.attrs:
             descriptions.append(self.describe(attr))
         return pl.Series(name=name, values=descriptions)
 
-    def describe(self, key):
+    def describe(self, key: str) -> str:
+        """Create a descriptions of one of the keywords."""
         match key:
             case "fitter":
                 return " ".join(f.describe() for f in self.fitter)

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -114,23 +114,16 @@ class VarLog():
             "fitter": fitter,
         }
 
-    def to_series(self, name: str | None = None):
-        """Create a series from a var_log.
+    def to_dict(self):
+        return {attr: self.describe(attr) for attr in self.attrs}
 
-        Parameters
-        ----------
-        name:
-
-
-        Returns
-        -------
-        series:
-            Polars series with the different attributes of the var log
-        """
-        descriptions = []
-        for attr in self.attrs:
-            descriptions.append(self.describe(attr))
-        return pl.Series(name=name, values=descriptions)
+    def to_md(self, name: str) -> str:
+        md_str = f"## {name}\n"
+        for key in self.attrs:
+            if len(getattr(self, key)) == 0:
+                continue
+            md_str += f"- {key}: {self.describe(key)}\n"
+        return md_str
 
     def describe(self, key: str) -> str:
         """Create a descriptions of one of the keywords."""

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -133,7 +133,8 @@ class VarLog():
             case _:
                 return " ".join(str(x) for x in getattr(self, key))
 
-
+    def __str__(self) -> str:
+        return "\n".join(self.to_md("").split("\n")[1:])
 
 class BaseFitter(ABC):
     """Base class for fitters."""

--- a/metasyn/distribution/base.py
+++ b/metasyn/distribution/base.py
@@ -42,6 +42,57 @@ def convert_to_series(values: Union[npt.NDArray, pl.Series]) -> pl.Series:
         series = pl.Series(series_array)
     return series
 
+class VarLog():
+    attrs = ["created_by", "method", "recipe", "fitter", "bic", "privacy"]
+
+    def __init__(self):
+        self.created_by = []
+        self.method = []
+        self.recipe = []
+        self.fitter = []
+        self.bic = []
+        self.privacy = []
+
+    def add(self, **kwargs):
+        for key, val in kwargs.items():
+            getattr(self, key).append(val)
+            if isinstance(val, BaseFitter):
+                self.add(privacy=val.privacy.describe())
+        return self
+
+    def extend(self, other):
+        for attr in self.attrs:
+            getattr(self, attr).extend(getattr(other, attr, []))
+        return self
+
+    @property
+    def creation_method(self) -> dict:
+        if len(self.fitter) == 0:
+            fitter = None
+        elif len(self.fitter) == 1:
+            fitter = self.fitter[0].to_dict()
+        else:
+            fitter = [f.to_dict() for f in self.fitter]
+        return {
+            "created_by": " ".join(self.created_by),
+            "fitter": fitter,
+        }
+
+    def to_series(self, name):
+        descriptions = []
+        for attr in self.attrs:
+            descriptions.append(self.describe(attr))
+        return pl.Series(name=name, values=descriptions)
+
+    def describe(self, key):
+        match key:
+            case "fitter":
+                return " ".join(f.describe() for f in self.fitter)
+            case _:
+                return " ".join(str(x) for x in getattr(self, key))
+
+
+
 class BaseFitter(ABC):
     """Base class for fitters."""
 
@@ -57,14 +108,18 @@ class BaseFitter(ABC):
             raise TypeError(f"To initialize fitter, supply a Privacy object, not {type(privacy)}.")
         self.privacy = privacy
 
-    def fit(self, values: Union[npt.NDArray, pl.Series]) -> BaseDistribution:
+    def fit(self, values: Union[npt.NDArray, pl.Series],
+            fit_log: VarLog | None = None) -> BaseDistribution:
+        if fit_log is None:
+            fit_log = VarLog()
         pl_series = convert_to_series(values)
         if len(pl_series) == 0:
+            fit_log.add(method="Using default distribution, because all values are NA.")
             return self.distribution.default_distribution(get_var_type(pl_series))
-        return self._fit(pl_series)
+        return self._fit(pl_series, fit_log)
 
     @abstractmethod
-    def _fit(self, series: pl.Series) -> BaseDistribution:
+    def _fit(self, series: pl.Series, fit_log) -> BaseDistribution:
         raise NotImplementedError
 
     @classmethod
@@ -101,6 +156,10 @@ class BaseFitter(ABC):
             "plugin": self.plugin,
             "plugin_version": self.plugin_version,
         }
+
+    def describe(self):
+        return (f"Fitter {self.__class__.__name__} version {self.version} from plugin "
+                f"{self.plugin}-{self.plugin_version}. " + self.privacy.describe())
 
 class DistributionLike(ABC):  #noqa: PLW1641
     """Objects that behave like distributions.
@@ -859,8 +918,9 @@ class ScipyDistribution(BaseDistribution):
 class ScipyFitter(BaseFitter):
     """Base fitter for scipy distributions."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
         param = self.distribution.scipy_class.fit(series)  # type: ignore  # All derived classes have dist_class
+        fit_log.add(method="Using a scipy distribution.")
         return self.distribution(*param)
 
 

--- a/metasyn/distribution/categorical.py
+++ b/metasyn/distribution/categorical.py
@@ -155,7 +155,23 @@ class MultinoulliFitter(BaseFitter):
 
     distribution: type[MultinoulliDistribution]
 
-    def _fit(self, series: pl.Series):
+    def _fit(self, series: pl.Series, fit_log):
         labels, counts = np.unique(series, return_counts=True)
         probs = counts/np.sum(counts)
+        fit_log.add(method=f"Multinoulli distribution with {len(counts)} categories and"
+                           f" {counts.sum()} counts.")
+
+        sorted_counts = counts[np.argsort(counts)]
+        sorted_labels = labels[np.argsort(counts)]
+        text = []
+        if len(counts) > 6:
+            for i in range(2):
+                text.append(f"{sorted_labels[i]}: {sorted_counts[i]}")
+            text.append("...")
+            for i in range(-2, 0):
+                text.append(f"{sorted_labels[i]}: {sorted_counts[i]}")
+        else:
+            for i in range(len(counts)):
+                text.append(f"{sorted_labels[i]}: {sorted_counts[i]}")
+        fit_log.add(method=", ".join(text))
         return self.distribution(labels, probs)

--- a/metasyn/distribution/constant.py
+++ b/metasyn/distribution/constant.py
@@ -10,6 +10,7 @@ from metasyn.distribution.base import (
     builtin_fitter,
     convert_to_series,
     metadist,
+    VarLog,
 )
 from metasyn.distribution.util import convert_numpy_datetime
 
@@ -40,7 +41,7 @@ class BaseConstantFitter(BaseFitter):
 
     distribution: type[BaseConstantDistribution]
 
-    def _fit(self, values: pl.Series, fit_log: list) -> BaseDistribution:
+    def _fit(self, values: pl.Series, fit_log: VarLog) -> BaseDistribution:
         # if unique, just get that value
         if values.n_unique() == 1:
             fit_log.add(method=f"All non-NA ){len(values)} values in the column are "

--- a/metasyn/distribution/constant.py
+++ b/metasyn/distribution/constant.py
@@ -7,10 +7,10 @@ import polars as pl
 from metasyn.distribution.base import (
     BaseDistribution,
     BaseFitter,
+    VarLog,
     builtin_fitter,
     convert_to_series,
     metadist,
-    VarLog,
 )
 from metasyn.distribution.util import convert_numpy_datetime
 

--- a/metasyn/distribution/constant.py
+++ b/metasyn/distribution/constant.py
@@ -40,11 +40,14 @@ class BaseConstantFitter(BaseFitter):
 
     distribution: type[BaseConstantDistribution]
 
-    def _fit(self, values: pl.Series) -> BaseDistribution:
+    def _fit(self, values: pl.Series, fit_log: list) -> BaseDistribution:
         # if unique, just get that value
         if values.n_unique() == 1:
+            fit_log.add(method=f"All non-NA ){len(values)} values in the column are "
+                        f"the same: {values[0]}")
             return self.distribution(values.unique()[0])
 
+        fit_log.add(method="Not all values are the same, taking most common value.")
         # otherwise get most common value
         val = values.value_counts(sort=True)[0,0]
         return self.distribution(val)

--- a/metasyn/distribution/exponential.py
+++ b/metasyn/distribution/exponential.py
@@ -45,12 +45,15 @@ class ExponentialDistribution(ScipyDistribution):
         }
 
 
+
 @builtin_fitter(distribution=ExponentialDistribution, var_type="continuous")
 class ExponentialFitter(BaseFitter):
     """Fitter for exponential distribution."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
+        fit_log.add(method="Removed all negative values.")
         series = series.filter(series > 0)
         if len(series) == 0:
+            fit_log.add(method="No non-NA values, using default distribution.")
             return self.distribution.default_distribution()
         return self.distribution(rate=1/expon.fit(series, floc=0)[1])

--- a/metasyn/distribution/faker.py
+++ b/metasyn/distribution/faker.py
@@ -74,9 +74,10 @@ class FakerFitter(BaseFitter):
 
     distribution: type[FakerDistribution]
 
-    def _fit(self, values, faker_type: str = "city", locale: str = "en_US"): # noqa: ARG002
+    def _fit(self, values, fit_log): # noqa: ARG002
         """Select the appropriate faker function and locale."""
-        return self.distribution(faker_type, locale)
+        fit_log.add(method="Cannot fit faker distribution, so using defaults")
+        return self.distribution.default_distribution()
 
 
 @metadist(name="core.faker", var_type="string")

--- a/metasyn/distribution/freetext.py
+++ b/metasyn/distribution/freetext.py
@@ -94,16 +94,18 @@ class FreeTextFitter(BaseFitter):
 
     distribution: type[FreeTextDistribution]
 
-    def _fit(self, series, max_values: int = 50):
+    def _fit(self, series, fit_log, max_values: int = 50):
         """Select the appropriate faker function and locale."""
         lang_str = detect_language(series[:max_values])
         if lang_str is None:
-            return self.distribution.default_distribution()
-
-        try:
-            Faker(lang_str)
-        except AttributeError:
-            lang_str = "EN"
+            fit_log.add(method="Could not determine language.")
+            # return self.distribution.default_distribution()
+        else:
+            try:
+                Faker(lang_str)
+            except AttributeError:
+                fit_log.add(method="Language not available in faker package, using engligh.")
+                lang_str = "EN"
 
         all_text = "\n".join(series)
         n_non_empty = (series != "").sum()
@@ -114,6 +116,7 @@ class FreeTextFitter(BaseFitter):
         else:
             avg_sentence = n_punctuation/len(series)
         avg_words = n_words/len(series)
+        fit_log.add(method="Using average number of sentences and words as parameters.")
         return self.distribution(lang_str, avg_sentence, avg_words)
 
 

--- a/metasyn/distribution/na.py
+++ b/metasyn/distribution/na.py
@@ -45,5 +45,5 @@ class NADistribution(BaseDistribution):
 class NAFitter(BaseFitter):
     """Fitter for NA distribution."""
 
-    def _fit(self, series):  # noqa: ARG002
+    def _fit(self, series, fit_log):  # noqa: ARG002
         return self.distribution()

--- a/metasyn/distribution/normal.py
+++ b/metasyn/distribution/normal.py
@@ -94,10 +94,11 @@ class LogNormalDistribution(ScipyDistribution):
 class LogNormalFitter(BaseFitter):
     """Fitter for log normal distribution."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
         try:
             sd, _, scale = self.distribution.scipy_class.fit(series, floc=0)
         except FitDataError:
+            fit_log.add(method="Failed to converge, using default distribution.")
             return self.distribution(0, 1)
         return self.distribution(np.log(scale), sd)
 
@@ -148,11 +149,13 @@ class ContinuousTruncatedNormalDistribution(ScipyDistribution):
 class ContinuousTruncatedNormalFitter(BaseFitter):
     """Fitter for continuous truncated normal fitter."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
         lower = series.min()
         upper = series.max()
         if lower == upper:
+            fit_log.add(method="Only one value in data, using very steep parameters.")
             return self.distribution(lower-1e-8, upper+1e-8, lower, 1)
+        fit_log.add(method="Fit normal distribution between lowest and highest value.")
         return self._fit_with_bounds(series, lower, upper)
 
     def _fit_with_bounds(self, values, lower, upper):

--- a/metasyn/distribution/poisson.py
+++ b/metasyn/distribution/poisson.py
@@ -50,7 +50,8 @@ class PoissonDistribution(ScipyDistribution):
 class PoissonFitter(BaseFitter):
     """Fitter for Poisson distribution."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
         mean_series = series.mean()
         mean_series = mean_series if mean_series >= 0 else 0
+        fit_log.add(method="Using mean (or 0 if mean is negative) as parameter.")
         return self.distribution(mean_series)

--- a/metasyn/distribution/regex.py
+++ b/metasyn/distribution/regex.py
@@ -101,7 +101,12 @@ class RegexFitter(BaseFitter):
 
     distribution: type[RegexDistribution]
 
-    def _fit(self, series, count_thres: Optional[int] = None, method: str = "auto"):
+    def __init__(self, privacy, count_thres: Optional[int] = None, method: str = "auto"):
+        self.count_thres = count_thres
+        self.method = method
+        super().__init__(privacy)
+
+    def _fit(self, series, fit_log):
         """Fit a regex to structured strings.
 
         Arguments
@@ -116,20 +121,29 @@ class RegexFitter(BaseFitter):
             The "auto" method switches between the "accurate" and "fast" methods depending on
             the number of characters (fast if #char > 10000) in the series.
         """
-        if method == "auto":
+        if self.method == "auto":
             if series.str.len_chars().mean() > 10:
                 method = "fast"
             else:
                 method = "accurate"
+        else:
+            method = self.method
 
         # Make count_thres ~= #series/100 up to 50 if in auto mode.
-        if count_thres is None:
+        if self.count_thres is None:
             count_thres = min(50, max(2, round(len(series)/50)))
+        else:
+            count_thres = self.count_thres
+
+        fit_log.add(method=f"Fitting regex using method '{self.method}' and "
+                       f"count threshold {self.count_thres}.")
 
         # Try to fit the series, if it cannot be fit, then use the default distribution.
         try:
             model = RegexModel.fit(series, count_thres=count_thres, method=method)
         except NotFittedError:
+            fit_log.add(method="Could not find regex matching the input, "
+                        "using default distribution.")
             return self.distribution.default_distribution()
         return self.distribution(model)
 

--- a/metasyn/distribution/uniform.py
+++ b/metasyn/distribution/uniform.py
@@ -427,17 +427,17 @@ class TimeUniformFitter(BaseDTUniformFitter):
     """Fitter for time uniform distribution."""
 
     # precision_possibilities = ["microseconds", "seconds", "minutes", "hours", "days"]
-    def _fit(self, values, fit_log):
+    def _fit(self, series, fit_log):
         fit_log.add(method="Using earliest and latest times as parameters.")
-        return TimeUniformDistribution(values.min(), values.max(), self._get_precision(values))
+        return TimeUniformDistribution(series.min(), series.max(), self._get_precision(series))
 
 @builtin_fitter(distribution=DateTimeUniformDistribution, var_type="datetime")
 class DateTimeUniformFitter(BaseDTUniformFitter):
     """Fitter for datetime uniform distribution."""
 
-    def _fit(self, values, fit_log):
+    def _fit(self, series, fit_log):
         fit_log.add(method="Using earliest and latest datetimes as parameters.")
-        return DateTimeUniformDistribution(values.min(), values.max(), self._get_precision(values))
+        return DateTimeUniformDistribution(series.min(), series.max(), self._get_precision(series))
 
 
 @builtin_fitter(distribution=DateUniformDistribution, var_type="date")
@@ -445,16 +445,17 @@ class DateUniformFitter(BaseDTUniformFitter):
     """Fitter for date uniform distribution."""
 
     precision_possibilities = ["days"]
-    def _fit(self, values, fit_log):
+    def _fit(self, series, fit_log):
         fit_log.add(method="Using earliest and latest dates as parameters.")
-        return DateUniformDistribution(values.min(), values.max())
+        return DateUniformDistribution(series.min(), series.max())
 
 @builtin_fitter(distribution=DurationUniformDistribution, var_type="duration")
 class DurationUniformFitter(BaseDTUniformFitter):
     """Fitter for the uniform duration distirbution."""
 
-    def _fit(self, values):
-        return DurationUniformDistribution(values.min(), values.max(), self._get_precision(values))
+    def _fit(self, series, fit_log):
+        fit_log.add(method="Using smallest and larges duration as parameters.")
+        return DurationUniformDistribution(series.min(), series.max(), self._get_precision(series))
 
     @classmethod
     def _get_precision(cls, values):

--- a/metasyn/distribution/uniform.py
+++ b/metasyn/distribution/uniform.py
@@ -65,7 +65,8 @@ class DiscreteUniformDistribution(ScipyDistribution):
 class DiscreteUniformFitter(BaseFitter):
     """Fitter for discrete uniform distribution."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
+        fit_log.add(method="Taking the highest and lowest value to compute the parameters.")
         return DiscreteUniformDistribution(series.min(), series.max()+1)
 
 
@@ -119,7 +120,8 @@ class ContinuousUniformDistribution(ScipyDistribution):
 class ContinuousUniformFitter(BaseFitter):
     """Fitter for continuous uniform distribution."""
 
-    def _fit(self, series):
+    def _fit(self, series, fit_log):
+        fit_log.add(method="Taking the highest and lowest value to compute the parameters.")
         return ContinuousUniformDistribution(series.min(), series.max())
 
 
@@ -424,14 +426,17 @@ class BaseDTUniformFitter(BaseFitter):
 class TimeUniformFitter(BaseDTUniformFitter):
     """Fitter for time uniform distribution."""
 
-    def _fit(self, values):
+    # precision_possibilities = ["microseconds", "seconds", "minutes", "hours", "days"]
+    def _fit(self, values, fit_log):
+        fit_log.add(method="Using earliest and latest times as parameters.")
         return TimeUniformDistribution(values.min(), values.max(), self._get_precision(values))
 
 @builtin_fitter(distribution=DateTimeUniformDistribution, var_type="datetime")
 class DateTimeUniformFitter(BaseDTUniformFitter):
     """Fitter for datetime uniform distribution."""
 
-    def _fit(self, values):
+    def _fit(self, values, fit_log):
+        fit_log.add(method="Using earliest and latest datetimes as parameters.")
         return DateTimeUniformDistribution(values.min(), values.max(), self._get_precision(values))
 
 
@@ -440,7 +445,8 @@ class DateUniformFitter(BaseDTUniformFitter):
     """Fitter for date uniform distribution."""
 
     precision_possibilities = ["days"]
-    def _fit(self, values):
+    def _fit(self, values, fit_log):
+        fit_log.add(method="Using earliest and latest dates as parameters.")
         return DateUniformDistribution(values.min(), values.max())
 
 @builtin_fitter(distribution=DurationUniformDistribution, var_type="duration")

--- a/metasyn/distribution/uniquekey.py
+++ b/metasyn/distribution/uniquekey.py
@@ -120,9 +120,10 @@ class UniqueKeyFitter(BaseFitter):
 
     distribution: type[UniqueKeyDistribution]
 
-    def _fit(self, series) -> UniqueKeyDistribution:
+    def _fit(self, series, fit_log) -> UniqueKeyDistribution:
         lower = series.min()
         high = series.max() + 1
         if len(series) == high-lower and np.all(series.to_numpy() == np.arange(lower, high)):
+            fit_log.add(method="Detected values to be consecutive")
             return self.distribution(lower, True)
         return self.distribution(lower, False)

--- a/metasyn/metaframe.py
+++ b/metasyn/metaframe.py
@@ -9,23 +9,16 @@ from copy import deepcopy
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union, no_type_check
+from typing import Any, Dict, List, Optional, Sequence, Union
 from warnings import warn
 
 import numpy as np
 import polars as pl
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore  # noqa
-
 from tqdm import tqdm
 
-# from metasyn.config import MetaConfig
 from metasyn.file import BaseFileInterface, file_interface_from_dict
 from metasyn.gmf import parse_gmf_dict
-from metasyn.privacy import BasePrivacy, get_privacy
+from metasyn.privacy import BasePrivacy
 from metasyn.util import set_global_seeds
 from metasyn.var import MetaVar
 
@@ -318,14 +311,7 @@ class MetaFrame:
             Validate the JSON file with a schema. If the file is a TOML file, then this will
             be ignored.
         """
-        if fp is None:
-            self.save_json(fp, validate)
-            return
-        fp_path = Path(fp)
-        if fp_path.suffix == ".toml":
-            self.save_toml(fp, validate)
-        else:
-            self.save_json(fp, validate)
+        self.save_json(fp, validate)
 
     @classmethod
     def load(cls, fp: Union[pathlib.Path, str], validate: bool = True,
@@ -333,7 +319,7 @@ class MetaFrame:
         """Read a MetaFrame from a JSON or TOML GMF file.
 
         Optionally, validate the saved JSON file against the JSON schema(s) included in the
-        package. A TOML cannot be validated against a schema currently.
+        package.
 
         Parameters
         ----------
@@ -348,11 +334,7 @@ class MetaFrame:
         MetaFrame:
             A restored MetaFrame from the file.
         """
-        fp_path = Path(fp)
-        if fp_path.suffix == ".toml":
-            return cls.load_toml(fp, validate, table_name=table_name)
-        else:
-            return cls.load_json(fp, validate, table_name=table_name)
+        return cls.load_json(fp, validate, table_name=table_name)
 
     def save_json(self, fp: Optional[Union[pathlib.Path, str]], validate: bool = True) -> None:
         """Serialize and save the MetaFrame to a JSON file, following the GMF format.
@@ -398,82 +380,6 @@ class MetaFrame:
         else:
             with open(fp, "r", encoding="utf-8") as f:
                 self_dict = json.load(f)
-
-        self_dict = parse_gmf_dict(self_dict, validate=validate)
-        return cls.from_dict(self_dict, table_name=table_name)
-
-    @no_type_check
-    def save_toml(self, fp: Optional[Union[pathlib.Path, str]], validate: bool = True) -> None:
-        try:
-            import tomlkit  # noqa: PLC0415
-        except ImportError:
-            raise ValueError(
-                "Please install tomlkit (pip install tomlkit) to enable support for saving to toml."
-            )
-        self_dict = _jsonify(self.to_dict())
-        if validate:
-            parse_gmf_dict(self_dict, validate=True)
-
-        all_doc = tomlkit.loads(tomlkit.dumps(self_dict))
-        doc = all_doc["tables"][0]
-        doc["n_rows"].comment("Number of rows")
-        doc["n_columns"].comment("""Number of columns
-
-# This is a metadata file with (limited) statistical information about each column separately in
-# a dataset. No information about correlations or other relationships between columns is included.
-# This file can be used to generate privacy-conscious synthetic data, which consequently has zero
-# expected correlations and relationships between columns.
-# For each column, the statistics can be either manually specified or estimated from real data.
-# This information, including how the estimation was done, is shown in the metadata below.
-#
-# For more information, see https://github.com/sodascience/metasyn
-""")
-        for i in range(self.n_columns):
-            var = self.meta_vars[i]
-            doc["vars"][i].comment(f"Metadata for column with name {var.name}")
-            fmi = round(self.n_rows * (1 - var.prop_missing))
-            doc["vars"][i]["prop_missing"].comment(
-                f"Fraction of missing values, remaining: {fmi} values"
-            )
-            # The below comment does not work, a tomlkit bug?
-            # doc["vars"][i]["distribution"]["unique"].add(tomlkit.comment(
-            # "Whether to generate unique values or not"))
-            parameter_comments = []
-            multi_default = (
-                var.distribution.matches_name("multinoulli")
-                and len(var.distribution.labels)
-                == len(var.distribution.default_distribution(var_type=var.var_type).labels)
-                and np.all(
-                    var.distribution.labels == var.distribution.default_distribution(
-                        var_type=var.var_type).labels
-                )
-            )
-            if "parameters" in var.creation_method:
-                parameters = ", ".join(var.creation_method["parameters"])
-                parameter_comments.append(
-                    f"The parameters {parameters} for column '{var.name}' were "
-                    "manually set by the user, no data was (directly) used."
-                )
-            elif var.distribution.matches_name("multinoulli") and multi_default:
-                parameter_comments.append(
-                    "This mulinoulli distribution is the default one, no data was used."
-                )
-            elif "privacy" in var.creation_method:
-                privacy = get_privacy(**var.creation_method["privacy"])
-                parameter_comments.append(privacy.comment(var))
-            par_comment = "\n# ".join(parameter_comments) + "\n\n"
-            doc["vars"][i]["distribution"]["parameters"].add(tomlkit.comment(par_comment))
-        if fp is None:
-            print(tomlkit.dumps(all_doc))
-        else:
-            with open(fp, "w", encoding="utf-8") as f:
-                tomlkit.dump(all_doc, f)
-
-    @classmethod
-    def load_toml(cls, fp: Union[pathlib.Path, str], validate: bool = True,
-                  table_name: Optional[str] = None) -> MetaFrame:
-        with open(fp, "rb") as f:
-            self_dict = tomllib.load(f)
 
         self_dict = parse_gmf_dict(self_dict, validate=validate)
         return cls.from_dict(self_dict, table_name=table_name)

--- a/metasyn/privacy.py
+++ b/metasyn/privacy.py
@@ -57,8 +57,10 @@ class BasePrivacy(ABC):
         """
         return f"Above are the parameters for the column {var.name}"
 
-    def describe(self):
-        return "The privacy was done using the basic privacy features of metasyn."
+    @abstractmethod
+    def describe(self) -> str:
+        pass
+
 
 class BasicPrivacy(BasePrivacy):
     """Class representing no privacy level.
@@ -71,6 +73,9 @@ class BasicPrivacy(BasePrivacy):
 
     def to_dict(self) -> dict:
         return BasePrivacy.to_dict(self)
+
+    def describe(self):
+        return "The privacy was done using the basic privacy features of metasyn."
 
 
 def get_privacy(name: str, parameters: Optional[dict] = None) -> BasePrivacy:

--- a/metasyn/privacy.py
+++ b/metasyn/privacy.py
@@ -55,8 +55,10 @@ class BasePrivacy(ABC):
         -------
             A comment on the privacy features.
         """
-        return "Above are the parameters for the column {var.name}"
+        return f"Above are the parameters for the column {var.name}"
 
+    def describe(self):
+        return "The privacy was done using the basic privacy features of metasyn."
 
 class BasicPrivacy(BasePrivacy):
     """Class representing no privacy level.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,12 +3,26 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from metasyn.builder import MetaFrameBuilder, VarBuilder
+from metasyn.builder import (
+    DistributionRecipe,
+    FindDistributionRecipe,
+    FitLog,
+    FitterRecipe,
+    MetaFrameBuilder,
+    UnqFindDistributionRecipe,
+    VarBuilder,
+)
 from metasyn.demo import demo_data
-from metasyn.distribution import DiscreteConstantDistribution
+from metasyn.distribution import (
+    ContinuousConstantDistribution,
+    DiscreteConstantDistribution,
+    DiscreteConstantFitter,
+    RegexDistribution,
+    RegexFitter,
+)
+from metasyn.distribution.base import BaseFitter, VarLog
 from metasyn.privacy import BasicPrivacy
 from metasyn.registry import DistributionRegistry
-from metasyn.builder import FitterRecipe, DistributionRecipe, FindDistributionRecipe, UnqFindDistributionRecipe
 
 
 @pytest.fixture(scope="module")
@@ -86,3 +100,21 @@ def test_find_fitter_error(builder):
     bld["Int64"].distribution = "regex"
     with pytest.raises(ValueError):
         bld.fit()
+
+def test_fit_log():
+    builder = MetaFrameBuilder()
+    builder.add_dataframe(demo_data("titanic")[:50])
+    builder["Fare"].distribution = ContinuousConstantDistribution(10)
+    builder["PassengerId"].distribution = {"unique": True}
+    builder["Age"].fitter = DiscreteConstantFitter(BasicPrivacy())
+    builder["Cabin"].fitter = RegexFitter(BasicPrivacy(), count_thres=20, method="fast")
+    builder.fit()
+    assert isinstance(builder.fit_log, FitLog)
+    assert isinstance(builder.fit_log["Age"], VarLog)
+    assert builder.fit_log["Fare"].created_by[0] == "user"
+    assert builder.fit_log["Fare"].recipe[0] == "User defined distribution."
+    assert builder.fit_log["PassengerId"].created_by[0] == "metasyn"
+    assert isinstance(builder.fit_log["PassengerId"].fitter[0], BaseFitter)
+    assert len(builder.fit_log["PassengerId"].bic) == 1
+    assert builder.fit_log["Cabin"].method[0].startswith("Fitting regex using method 'fast'") == 1
+    assert builder.fit_log["Cabin"].privacy[0].startswith("The privacy was done using the basic")


### PR DESCRIPTION
The functionality of the fit log is meant to audit the process of fitting the data. You can see which categories got deleted while following the disclosure control process. You can also see which distributions are considered during the fitting process. And for the micro-aggregation process, you can see which parameters the fitting process eventually landed on.

The API change is rather a big one, and I wish it weren't necessary, but I think the change will allow more flexibility in the future.

This also removes the toml GMF file, since most of that has now been superseeded by the fit log.